### PR TITLE
Remove Perm in Parameter Path

### DIFF
--- a/bin/end_to_end.sh
+++ b/bin/end_to_end.sh
@@ -49,9 +49,9 @@ if [[ "$(admin_url)" =~ "Unknown" ]]; then
 fi
 
 export FORMS_ADMIN_URL="$(admin_url)"
-export SIGNON_USERNAME="$(get_param /${environment}/smoketests/perm/signon/username)"
-export SIGNON_OTP="$(get_param /${environment}/smoketests/perm/signon/secret)"
-export SIGNON_PASSWORD="$(get_param /${environment}/smoketests/perm/signon/password)"
+export SIGNON_USERNAME="$(get_param /${environment}/smoketests/signon/username)"
+export SIGNON_OTP="$(get_param /${environment}/smoketests/signon/secret)"
+export SIGNON_PASSWORD="$(get_param /${environment}/smoketests/signon/password)"
 export SETTINGS__GOVUK_NOTIFY__API_KEY="$(get_param /${environment}/smoketests/notify/api-key)"
 
 cd ..


### PR DESCRIPTION
The `perm` switch in the parameter store path for the Signon Credentials is no longer required.


### Notes
I have run this agains each environment and it works because I have added the necessary params in parameter store.