### PR TITLE
Revert "Replace pry with debug"

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -3,7 +3,7 @@ source "https://rubygems.org"
 ruby "3.1.3"
 
 gem "rotp"
-gem "debug"
+gem "pry"
 gem "rspec"
 gem "capybara"
 gem "notifications-ruby-client"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -13,16 +13,11 @@ GEM
       regexp_parser (>= 1.5, < 3.0)
       xpath (~> 3.2)
     childprocess (4.1.0)
-    debug (1.8.0)
-      irb (>= 1.5.0)
-      reline (>= 0.3.1)
+    coderay (1.1.3)
     diff-lcs (1.5.0)
-    io-console (0.6.0)
-    irb (1.8.0)
-      rdoc (~> 6.5)
-      reline (>= 0.3.6)
     jwt (2.5.0)
     matrix (0.4.2)
+    method_source (1.0.0)
     mini_mime (1.1.2)
     nokogiri (1.13.9-arm64-darwin)
       racc (~> 1.4)
@@ -32,18 +27,15 @@ GEM
       racc (~> 1.4)
     notifications-ruby-client (5.4.0)
       jwt (>= 1.5, < 3)
-    psych (5.1.0)
-      stringio
+    pry (0.14.1)
+      coderay (~> 1.1)
+      method_source (~> 1.0)
     public_suffix (5.0.0)
     racc (1.6.0)
     rack (3.0.0)
     rack-test (2.0.2)
       rack (>= 1.3)
-    rdoc (6.5.0)
-      psych (>= 4.0.0)
     regexp_parser (2.6.0)
-    reline (0.3.8)
-      io-console (~> 0.5)
     rexml (3.2.5)
     rotp (6.2.0)
     rspec (3.12.0)
@@ -65,7 +57,6 @@ GEM
       rexml (~> 3.2, >= 3.2.5)
       rubyzip (>= 1.2.2, < 3.0)
       websocket (~> 1.0)
-    stringio (3.0.8)
     webdrivers (5.2.0)
       nokogiri (~> 1.6)
       rubyzip (>= 1.3.0)
@@ -84,8 +75,8 @@ PLATFORMS
 
 DEPENDENCIES
   capybara
-  debug
   notifications-ruby-client
+  pry
   rotp
   rspec
   selenium-webdriver

--- a/README.md
+++ b/README.md
@@ -57,12 +57,10 @@ For example:
 GUI=1 SKIP_SIGNON=1 FORMS_ADMIN_URL='http://localhost:3000/' bundle exec rspec
 ```
 
-To open the debugger while running the tests, the [ruby debug gem](https://github.com/ruby/debug) is included.
-
-Add the following within the specs at the line you would like the test to pause:
+To debug errors, use pry to set breakpoints:
 
 ```ruby
-debugger
+  require 'pry'; binding.pry
 ```
 
-You can then use the command line debugger to check the contents of variables and other debugging tasks. To continue the tests, type `continue` and press enter.
+You can then use the command line debugger to check the contents of variables and other debugging tasks.

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,6 +1,5 @@
 require 'capybara/rspec'
 require 'selenium/webdriver'
-require 'debug'
 
 options = Selenium::WebDriver::Chrome::Options.new
 options.add_preference(:download, prompt_for_download: false,


### PR DESCRIPTION
This reverts commit dd82ae383eb7c1311ce8d0249068eed1fd9af601.

The e2e tests started to fail as the debug gem has a dependency on libyaml, which the Amazon Linux docker image did not have. So it failed on bundle install.