### PR TITLE
Update examples for gds-cli

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,12 +33,12 @@ SKIP_SIGNON=1 FORMS_ADMIN_URL='http://localhost:3000/' bundle exec rspec
 
 To run the tests against one of the standard environemnts you can use the end_to_end.sh script.
 
-Run it in an authenticated shell with permission to access SSM params in gds-forms-deploy using the gds-cli or aws-vault
+Run it in an authenticated shell with permission to access SSM params in forms-deploy using the gds-cli or aws-vault
 
 For example, to run the tests against the development environment, use:
 
 ```bash
-gds-cli aws gds-forms-deploy-readonly bin/end_to_end.sh dev
+gds-cli aws forms-deploy-readonly bin/end_to_end.sh dev
 ```
 
 Change `dev` to `staging` or `production` to run the tests against those environments.

--- a/bin/end_to_end.sh
+++ b/bin/end_to_end.sh
@@ -16,12 +16,12 @@ if [[ -z "$environment" ]] || [[ "$1" == "help" ]] || [[ -z "$AWS_ACCESS_KEY_ID"
   echo "Runs the Capybara end-to-end tests for the given environment.
 
 Run in an authenticated shell with permission to access ssm params in
-gds-forms-deploy using the gds-cli or aws-vault
+forms-deploy using the gds-cli or aws-vault
 
 Usage: $0 dev|staging|production
 
 Example:
-gds-cli aws gds-forms-deploy-readonly -- $0 dev
+gds-cli aws forms-deploy-readonly -- $0 dev
 "
   exit 0
 fi


### PR DESCRIPTION
The latest versions of gds-cli don't prefix the GOV.UK Forms AWS accounts with `gds-` (see https://github.com/alphagov/gds-cli/pull/735); this commit updates the documentation of the end to end test scripts to match.