### PR TITLE
Add action for email confirmation form

### DIFF
--- a/spec/features/complete_spec.rb
+++ b/spec/features/complete_spec.rb
@@ -187,6 +187,10 @@ feature "Full lifecycle of a form", type: :feature do
     expect(page).to have_content answer_text
 
     expected_mail_reference = page.find('#notification-id', visible: false).value
+    
+    if page.has_content? "Do you want to get an email confirming your form has been submitted?"
+      choose "No", visible: false
+    end
 
     click_button 'Submit'
 


### PR DESCRIPTION
### What problem does this pull request solve?

Adds logic to select 'No' if the email confirmation is present. Without this, the test will fail on environments with the email confirmation feature flag enabled. There's a separate backlog card (https://trello.com/c/bnWjTvpU/1227-add-an-e2e-to-cover-adding-confirmation-email-being-filled-in-on-forms) for making the tests work with the email confirmation and check that the email is actually sent.
Trello card: None.

<!-- Add some description here about what the PR is about, even if you have a Trello card to link to -->

### Things to consider when reviewing

<!-- If this section isn't relevant for your PR feel free to edit or remove it -->

- Does it work when run on your machine?
- Is it clear what the code is doing?
- Do the commit messages explain why the changes were made?
