### PR TITLE
Use auth0 database connection

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ bundle install
 
 ### Running the tests locally
 
-You can run the tests against localhost using the following command: 
+You can run the tests against localhost using the following command:
 
 ```
 SKIP_SIGNON=1 FORMS_ADMIN_URL='http://localhost:3000/' bundle exec rspec
@@ -38,7 +38,7 @@ Run it in an authenticated shell with permission to access SSM params in forms-d
 For example, to run the tests against the development environment, use:
 
 ```bash
-gds-cli aws forms-deploy-readonly bin/end_to_end.sh dev
+gds aws forms-deploy-readonly bin/end_to_end.sh dev
 ```
 
 Change `dev` to `staging` or `production` to run the tests against those environments.
@@ -66,3 +66,13 @@ debugger
 ```
 
 You can then use the command line debugger to check the contents of variables and other debugging tasks. To continue the tests, type `continue` and press enter.
+
+### Changing Auth0 connection
+
+When Auth0 is the enabled auth provider for an environment you can switch between using a database or passwordless connection. The database connection uses a typical username and password flow set up exclusively for use by the end-to-end tests.
+
+The database connection is used by default, but the passwordless flow can be enabled by setting the USE_AUTH0_PASSWORDLESS_CONNECTION variable, e.g.:
+
+```
+gds aws forms-deploy-readonly -- env USE_AUTH0_PASSWORDLESS_CONNECTION=1 bin/end_to_end.sh dev
+```

--- a/bin/end_to_end.sh
+++ b/bin/end_to_end.sh
@@ -60,6 +60,7 @@ export SETTINGS__GOVUK_NOTIFY__API_KEY="$(get_param /${environment}/smoketests/n
 export AUTH0_EMAIL_USERNAME="$(get_param /${environment}/smoketests/auth0/email-username)"
 export AUTH0_GMAIL_ADDRESS="$(get_param /${environment}/smoketests/auth0/gmail-address)"
 export AUTH0_GOOGLE_APP_PASSWORD="$(get_param /${environment}/smoketests/auth0/gmail-password)"
+export AUTH0_USER_PASSWORD="$(get_param /${environment}/smoketests/auth0/auth0-user-password)"
 
 cd ..
 bundle install


### PR DESCRIPTION
Trello card: https://trello.com/c/plEH5HIE/1125-improve-auth0-e2e-tests-update-e2e-tests-to-use-new-auth0-username-password

Instead of signing into Auth0 the same way as a real user, we've added a username and password flow for automation purposes (see alphagov/forms-admin#699, alphagov/forms-deploy#371). This is a lot easier to manage in scripts, and so should be more reliable.

This PR updates the end to end tests to use this method when Auth0 sign in is present. This has been tested against dev.