### PR TITLE
Add assertions to test whether signing in was successful

### DIFF
--- a/spec/features/complete_spec.rb
+++ b/spec/features/complete_spec.rb
@@ -224,6 +224,11 @@ feature "Full lifecycle of a form", type: :feature do
     else
       sign_in_to_gds_sso
     end
+
+    expect(page.current_host).to eq forms_admin_url
+    expect(page.current_path).to eq "/"
+    expect(page.find("h1")).to have_content "GOV.UK Forms"
+
     info "Sign in successful"
   end
 


### PR DESCRIPTION
We had some failures recently where it looked like signing in with Auth0
database connection was successful, but then we got the error

```
     Failure/Error: expect(page).to have_content 'GOV.UK Forms'
       expected to find text "GOV.UK Forms" in "Sign in\nSign in to GOV\u2060.\u2060UK Forms\nEmail address\nEmail address\nContinue\nIf you do not have one already, you can create an account"
     # ./spec/features/complete_spec.rb:33:in `build_a_new_form'
     # ./spec/features/complete_spec.rb:17:in `block (2 levels) in <top (required)>'
```

This commit changes the `sign_in` method to expect that the page looks like the GOV.UK Forms homepage before stating that signing in was successful.