### PR TITLE
Test confirmation email feature in end to end tests

### DIFF
--- a/spec/features/complete_spec.rb
+++ b/spec/features/complete_spec.rb
@@ -1,4 +1,6 @@
 feature "Full lifecycle of a form", type: :feature do
+  let(:test_email_address) { "govuk-forms-automation-tests@digital.cabinet-office.gov.uk" }
+
   let(:form_name) { "capybara test form #{Time.now().strftime("%Y-%m-%d %H:%M.%S")}" }
   let(:selection_question) { "Do you want to remain anonymous?" }
   let(:question_text) { "What is your name?" }

--- a/spec/features/complete_spec.rb
+++ b/spec/features/complete_spec.rb
@@ -17,8 +17,11 @@ feature "Full lifecycle of a form", type: :feature do
       live_form_link = page.find('[data-copy-target]').text
 
       unless bypass_end_to_end_tests('forms-runner', live_form_link)
+        # Testing alternate routes (basic routing with a skip question)
         form_is_filled_in_by_form_filler(live_form_link, skip_question: false)
         form_is_filled_in_by_form_filler(live_form_link, skip_question: true)
+        # Testing confirmation email
+        form_is_filled_in_by_form_filler(live_form_link, confirmation_email: test_email_address)
       end
 
       delete_form

--- a/spec/support/feature_helpers.rb
+++ b/spec/support/feature_helpers.rb
@@ -51,7 +51,7 @@ module FeatureHelpers
 
     expect(page.find("h1")).to have_content "Provide contact details for support"
     check "Email", visible: false
-    fill_in "Enter the email address", with: "govuk-forms-automation-tests@digital.cabinet-office.gov.uk"
+    fill_in "Enter the email address", with: test_email_address
     click_button "Save and continue"
 
     next_form_creation_step 'Make your form live'
@@ -144,11 +144,11 @@ module FeatureHelpers
 
       expected_mail_reference = page.find('#notification-id', visible: false).value
 
-      fill_in "What email address should completed forms be sent to?", with: "govuk-forms-automation-tests@digital.cabinet-office.gov.uk", fill_options: { clear: :backspace }
+      fill_in "What email address should completed forms be sent to?", with: test_email_address, fill_options: { clear: :backspace }
       click_button "Save and continue"
 
       expect(page.find("h1")).to have_content 'Confirmation code sent'
-      expect(page.find("main")).to have_content "govuk-forms-automation-tests@digital.cabinet-office.gov.uk"
+      expect(page.find("main")).to have_content test_email_address
 
       click_link "Enter the email address confirmation code"
 
@@ -170,7 +170,7 @@ module FeatureHelpers
       next_form_creation_step 'Set the email address completed forms will be sent to'
 
       expect(page.find("h1")).to have_content 'What email address should completed forms be sent to?'
-      fill_in "What email address should completed forms be sent to?", with: "govuk-forms-automation-tests@digital.cabinet-office.gov.uk"
+      fill_in "What email address should completed forms be sent to?", with: test_email_address
       click_button "Save and continue"
     end
   end


### PR DESCRIPTION
### What problem does this pull request solve?

Trello card: https://trello.com/c/bnWjTvpU <!-- link -->

<!-- Add some description here about what the PR is about, even if you have a Trello card to link to -->

Extend the end to end tests to test a form filler requesting an email confirmation.

This uses the same mechanism as the test of the submission email, where we use the Notify API to see if the notification has been delivered. The confirmation email reference is needed for this, so to test this locally you will need the latest main branch of forms-runner checked out, with the changes from alphagov/forms-runner#500.

I've tested this locally.

### Things to consider when reviewing

<!-- If this section isn't relevant for your PR feel free to edit or remove it -->

- Ensure that you consider the wider context.
- Does it work when run on your machine?
- Is it clear what the code is doing?
- Do the commit messages explain why the changes were made?
- Has all relevant documentation been updated?