### PR TITLE
specify which link to click on

### DIFF
--- a/spec/support/feature_helpers.rb
+++ b/spec/support/feature_helpers.rb
@@ -21,7 +21,7 @@ module FeatureHelpers
 
     create_a_single_line_of_text_question
 
-    click_link 'Go to your questions'
+    first(:link, "your questions").click
 
     add_a_route
 


### PR DESCRIPTION
### What problem does this pull request solve?
https://github.com/alphagov/forms-admin/pull/805 introduced a second nav link. This commit make sure we using the link in the notification banner to go to the list of questions


Trello card: https://trello.com/c/BV55CFc9/1229-update-save-question-notification-banner-with-calls-to-action-ctas

<!-- Add some description here about what the PR is about, even if you have a Trello card to link to -->

### Things to consider when reviewing

<!-- If this section isn't relevant for your PR feel free to edit or remove it -->

- Ensure that you consider the wider context.
- Does it work when run on your machine?
- Is it clear what the code is doing?
- Do the commit messages explain why the changes were made?
- Has all relevant documentation been updated?
