### PR TITLE
Tweak add/edit question page of the e2e tests

### DIFF
--- a/spec/support/feature_helpers.rb
+++ b/spec/support/feature_helpers.rb
@@ -92,10 +92,14 @@ module FeatureHelpers
     click_button "Continue"
 
     expect(page.find("h1")).to have_content 'Edit question'
-    click_button "Save and add next question"
+    click_button "Save question"
   end
 
   def create_a_single_line_of_text_question
+    within(page.find(".govuk-notification-banner__content")) do
+      click_on "Add a question"
+    end
+
     expect(page.find("h1")).to have_content 'What kind of answer do you need to this question?'
     choose "Text", visible: false
     click_button "Continue"

--- a/spec/support/feature_helpers.rb
+++ b/spec/support/feature_helpers.rb
@@ -91,6 +91,7 @@ module FeatureHelpers
     fill_in "Option 2", :with => "No"
     click_button "Continue"
 
+    expect(page.find("h1")).to have_content 'Edit question'
     click_button "Save and add next question"
   end
 


### PR DESCRIPTION
### What problem does this pull request solve?

See individual commits

Trello card: https://trello.com/c/4fXdQIRk/1230-simplify-calls-to-action-ctas-at-the-bottom-of-the-edit-question-page

<!-- Add some description here about what the PR is about, even if you have a Trello card to link to -->

### Things to consider when reviewing

<!-- If this section isn't relevant for your PR feel free to edit or remove it -->

- Ensure that you consider the wider context.
- Does it work when run on your machine?
- Is it clear what the code is doing?
- Do the commit messages explain why the changes were made?
- Has all relevant documentation been updated?
