### PR TITLE
Add product pages e2e tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,6 +39,11 @@ You can run the tests against localhost using the following command:
 SKIP_AUTH=1 FORMS_ADMIN_URL='http://localhost:3000/' bundle exec rspec
 ```
 
+### Skipping the product pages
+
+The end to end tests can be run without visiting the product pages by setting
+the `SKIP_PRODUCT_PAGES` environment variable to `1`.
+
 ### Running the tests against remote environments
 
 To run the tests against one of the standard environemnts you can use the end_to_end.sh script.

--- a/bin/load_env_vars.sh
+++ b/bin/load_env_vars.sh
@@ -14,6 +14,20 @@ function admin_url() {
   esac
 }
 
+function product_pages_url() {
+  local environment="$1"
+
+  case $environment in
+    "dev") echo "https://www.dev.forms.service.gov.uk" ;;
+    "staging") echo "https://www.staging.forms.service.gov.uk" ;;
+    "production") echo "https://www.forms.service.gov.uk" ;;
+    *)
+      echo "Unknown environment: ${environment}"
+      exit 1
+      ;;
+  esac
+}
+
 function get_param() {
   path="$1"
 
@@ -32,6 +46,7 @@ function set_env_vars() {
   fi
 
   export FORMS_ADMIN_URL="$(admin_url $environment)"
+  export PRODUCT_PAGES_URL="$(product_pages_url $environment)"
   export SETTINGS__GOVUK_NOTIFY__API_KEY="$(get_param /${environment}/smoketests/notify/api-key)"
   export AUTH0_EMAIL_USERNAME="$(get_param /${environment}/smoketests/auth0/email-username)"
   export AUTH0_USER_PASSWORD="$(get_param /${environment}/smoketests/auth0/auth0-user-password)"

--- a/spec/features/complete_spec.rb
+++ b/spec/features/complete_spec.rb
@@ -5,9 +5,16 @@ feature "Full lifecycle of a form", type: :feature do
   let(:selection_question) { "Do you want to remain anonymous?" }
   let(:question_text) { "What is your name?" }
   let(:answer_text) { "test name" }
+  let(:start_url) do
+    if skip_product_pages?
+      forms_admin_url
+    else
+      product_pages_url
+    end
+  end
 
   before do
-    Capybara.app_host = forms_admin_url
+    Capybara.app_host = start_url
   end
 
   scenario "Form is created, made live by form admin user and completed by a member of the public" do


### PR DESCRIPTION
This commit adds the product pages to the end-to-end tests run against the forms system.

It starts the journey from the product pages by following the Sign in link there. Unless SKIP_PRODUCT_PAGES is set.

This is a very simple test; that the product pages are up and have a link to the admin. That's probably the most important part of the product pages journey and we could build on it later if we want a more detailed test.

### What problem does this pull request solve?

Trello card: https://trello.com/c/bKkFUV5X/1193-add-product-pages-to-the-e2e-tests

This can't be merged until the [PR which sets the variables which point to the product pages](https://github.com/alphagov/forms-deploy/pull/481) have been merged and applied.


### Things to consider when reviewing

<!-- If this section isn't relevant for your PR feel free to edit or remove it -->

- Ensure that you consider the wider context.
- Does it work when run on your machine?
- Is it clear what the code is doing?
- Do the commit messages explain why the changes were made?
- Has all relevant documentation been updated?
