### PR TITLE
Bump bundler from 2.4.21 to 2.5.3

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -11,7 +11,6 @@ USER ruby
 
 COPY --chown=ruby:ruby . ./
 
-RUN gem install bundler -v 2.4.21
 RUN bundle install
 
 CMD ["bundle", "exec", "rspec"]

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -91,4 +91,4 @@ RUBY VERSION
    ruby 3.2.2p53
 
 BUNDLED WITH
-   2.4.21
+   2.5.3


### PR DESCRIPTION
### What problem does this pull request solve?

<!-- Add some description here about what the PR is about, even if you have a Trello card to link to -->

Bumps [bundler](https://rubygems.org/gems/bundler) from 2.4.21 to 2.5.3.
- [Release notes](https://github.com/rubygems/rubygems/releases/tag/bundler-v2.5.3)
- [Changelog](https://github.com/rubygems/rubygems/blob/master/bundler/CHANGELOG.md)
- [Commits](rubygems/rubygems@bundler-v2.4.21...bundler-v2.5.3)

### Things to consider when reviewing

<!-- If this section isn't relevant for your PR feel free to edit or remove it -->

- Ensure that you consider the wider context.
- Does it work when run on your machine?
- Is it clear what the code is doing?
- Do the commit messages explain why the changes were made?
- Has all relevant documentation been updated?