### PR TITLE
Add forms-product-page URL to examples in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,7 +36,7 @@ Ensure both the forms-admin and forms-runner services are also configured to use
 You can run the tests against localhost using the following command:
 
 ```
-SKIP_AUTH=1 FORMS_ADMIN_URL='http://localhost:3000/' bundle exec rspec
+SKIP_AUTH=1 FORMS_ADMIN_URL='http://localhost:3000/' PRODUCT_PAGES_URL='http://localhost:3002/' bundle exec rspec
 ```
 
 ### Skipping the product pages
@@ -69,7 +69,7 @@ chrome in visual rather than headless mode.
 For example:
 
 ```
-GUI=1 SKIP_AUTH=1 FORMS_ADMIN_URL='http://localhost:3000/' bundle exec rspec
+GUI=1 SKIP_AUTH=1 FORMS_ADMIN_URL='http://localhost:3000/' PRODUCT_PAGES_URL='http://localhost:3002/' bundle exec rspec
 ```
 
 To open the debugger while running the tests, the [ruby debug gem](https://github.com/ruby/debug) is included.


### PR DESCRIPTION
### What problem does this pull request solve?

<!-- Add some description here about what the PR is about, even if you have a Trello card to link to -->

This makes it easier to run the end to end tests locally by copying the examples out of the readme and running directly.

### Things to consider when reviewing

<!-- If this section isn't relevant for your PR feel free to edit or remove it -->

- Ensure that you consider the wider context.
- Does it work when run on your machine?
- Is it clear what the code is doing?
- Do the commit messages explain why the changes were made?
- Has all relevant documentation been updated?