### PR TITLE
Set PRODUCT_PAGES_URL in dockerfile_test.sh

### DIFF
--- a/bin/dockerfile_test.sh
+++ b/bin/dockerfile_test.sh
@@ -27,6 +27,7 @@ if [[ -z "$IMAGE_TO_TEST" ]]; then
 fi
 
 if [ -z "$FORMS_ADMIN_URL" ] || \
+   [ -z "$PRODUCT_PAGES_URL" ] || \
    [ -z "$AUTH0_EMAIL_USERNAME" ] || \
    [ -z "$AUTH0_USER_PASSWORD" ] || \
    [ -z "$SETTINGS__GOVUK_NOTIFY__API_KEY" ]; then
@@ -38,6 +39,7 @@ fi
 echo 'Running the tests against dev environment'
 docker run --rm \
   -e FORMS_ADMIN_URL \
+  -e PRODUCT_PAGES_URL \
   -e AUTH0_EMAIL_USERNAME \
   -e AUTH0_USER_PASSWORD \
   -e SETTINGS__GOVUK_NOTIFY__API_KEY \

--- a/bin/dockerfile_test.sh
+++ b/bin/dockerfile_test.sh
@@ -9,7 +9,7 @@ function help() {
   Usage: $0 <DOCKER IMAGE TO TEST>
 
   Example:
-  gds-cli aws forms-deploy-readonly -- $0 'existing-docker-image-tag'
+  gds aws forms-deploy-readonly -- $0 'existing-docker-image-tag'
   "
 exit 1
 }

--- a/bin/end_to_end.sh
+++ b/bin/end_to_end.sh
@@ -21,7 +21,7 @@ forms-deploy using the gds-cli or aws-vault
 Usage: $0 dev|staging|production
 
 Example:
-gds-cli aws forms-deploy-readonly -- $0 dev
+gds aws forms-deploy-readonly -- $0 dev
 "
   exit 0
 fi


### PR DESCRIPTION
### What problem does this pull request solve?

The `PRODUCT_PAGES_URL` env var wasn't set in dockerfile_test.sh, so the e2e-image pipeline was failing. This PR sets the env var, and also updates references to `gds-cli`

<!-- Add some description here about what the PR is about, even if you have a Trello card to link to -->

### Things to consider when reviewing

<!-- If this section isn't relevant for your PR feel free to edit or remove it -->

- Ensure that you consider the wider context.
- Does it work when run on your machine?
- Is it clear what the code is doing?
- Do the commit messages explain why the changes were made?
- Has all relevant documentation been updated?
