### PR TITLE
Rename submission email reference

### DIFF
--- a/spec/support/feature_helpers.rb
+++ b/spec/support/feature_helpers.rb
@@ -241,7 +241,7 @@ module FeatureHelpers
       expect(page).to have_content answer_text
     end
 
-    submission_email_reference = find_notification_reference("notification-id")
+    submission_email_reference = find_notification_reference("submission-email-reference")
     confirmation_email_reference = nil
 
     if page.has_content? "Do you want to get an email confirming your form has been submitted?"

--- a/spec/support/feature_helpers.rb
+++ b/spec/support/feature_helpers.rb
@@ -1,8 +1,10 @@
 # frozen_string_literal: true
 
-require_relative '../../services/notify_service'
+require_relative "./notify_helpers"
 
 module FeatureHelpers
+  include NotifyHelpers
+
   def forms_admin_url
     ENV.fetch("FORMS_ADMIN_URL") { raise "You must set $FORMS_ADMIN_URL"}
   end
@@ -323,37 +325,6 @@ module FeatureHelpers
 
     fill_in "Password", :with => auth0_user_password
     click_button "Continue"
-  end
-
-  def get_confirmation_from_notify(expected_mail_reference, confirmation_code: false)
-    email = NotifyService.new.get_email(expected_mail_reference)
-
-    start_time = Time.now
-    logger.debug "Waiting 3sec for mail delivery to do its thing."
-    sleep 3
-    try = 0
-    while(Time.now - start_time < 5000) do
-      try += 1
-
-      if confirmation_code
-        unless email.collection.first.body.nil?
-          code = email.collection.first.body.match(/\d{6}/).to_s
-          logger.debug "Received the following code from Notify: “#{code}“"
-          return code
-        end
-      else
-        unless email.collection.first.status.nil?
-          status = email.collection.first.status
-          logger.debug "Received the following status from Notify: “#{status}“"
-          return email.collection.first
-        end
-      end
-
-      wait_time = try + ((Time.now - start_time) ** 0.5)
-      logger.debug 'failed. Sleeping %0.2fs.' % wait_time
-      sleep wait_time
-    end
-    return false
   end
 
   def bypass_end_to_end_tests(service_name, link)

--- a/spec/support/feature_helpers.rb
+++ b/spec/support/feature_helpers.rb
@@ -171,9 +171,7 @@ module FeatureHelpers
 
       expect(page.find("h1")).to have_content "Enter the confirmation code"
 
-      confirmation_code = get_confirmation_from_notify(expected_mail_reference, confirmation_code: true)
-
-      abort("ABORT!!! #{expected_mail_reference} could not be found in Notify!!!") unless confirmation_code
+      confirmation_code = wait_for_confirmation_code(expected_mail_reference)
 
       fill_in "Enter the confirmation code", with: confirmation_code
 
@@ -265,9 +263,7 @@ module FeatureHelpers
     logger.info "As a form processor"
     logger.info "When a form filler has submitted their answers"
     logger.info "Then I can see their submission in my email inbox"
-    form_submission_email = get_confirmation_from_notify(expected_mail_reference)
-
-    abort("ABORT!!! #{expected_mail_reference} could not be found in Notify!!!") unless form_submission_email
+    form_submission_email = wait_for_notification(expected_mail_reference)
 
     logger.info "And I can see their answers"
     if skip_question
@@ -287,9 +283,7 @@ module FeatureHelpers
       logger.info "When I have filled out a form and requested a confirmation email"
       logger.info "Then I can see the confirmation in my email inbox"
 
-      confirmation_email_notification = get_confirmation_from_notify(expected_confirmation_mail_reference)
-
-      abort("ABORT!!! #{expected_confirmation_mail_reference} could not be found in Notify!!!") unless confirmation_email_notification
+      confirmation_email_notification = wait_for_notification(expected_confirmation_mail_reference)
     end
   end
 

--- a/spec/support/feature_helpers.rb
+++ b/spec/support/feature_helpers.rb
@@ -159,7 +159,7 @@ module FeatureHelpers
 
       expect(page.find("h1")).to have_content 'Set the email address for completed forms'
 
-      expected_mail_reference = page.find('#notification-id', visible: false).value
+      expected_mail_reference = find_notification_reference("notification-id")
 
       fill_in "What email address should completed forms be sent to?", with: test_email_address, fill_options: { clear: :backspace }
       click_button "Save and continue"
@@ -241,15 +241,15 @@ module FeatureHelpers
       expect(page).to have_content answer_text
     end
 
-    expected_mail_reference = page.find('#notification-id', visible: false).value
-    expected_confirmation_mail_reference = nil
+    submission_email_reference = find_notification_reference("notification-id")
+    confirmation_email_reference = nil
 
     if page.has_content? "Do you want to get an email confirming your form has been submitted?"
       if confirmation_email
         logger.info "And I can request a confirmation email"
         choose "Yes", visible: false
         fill_in "email_confirmation_form[confirmation_email_address]", with: confirmation_email
-        expected_confirmation_mail_reference = page.find("#confirmation-email-reference", visible: false).value
+        confirmation_email_reference = find_notification_reference("confirmation-email-reference")
       else
         choose "No", visible: false
       end
@@ -263,7 +263,8 @@ module FeatureHelpers
     logger.info "As a form processor"
     logger.info "When a form filler has submitted their answers"
     logger.info "Then I can see their submission in my email inbox"
-    form_submission_email = wait_for_notification(expected_mail_reference)
+
+    form_submission_email = wait_for_notification(submission_email_reference)
 
     logger.info "And I can see their answers"
     if skip_question
@@ -277,13 +278,13 @@ module FeatureHelpers
       expect(form_submission_email.body).to have_content answer_text
     end
 
-    if expected_confirmation_mail_reference
+    if confirmation_email_reference
       logger.info
       logger.info "As a form filler"
       logger.info "When I have filled out a form and requested a confirmation email"
       logger.info "Then I can see the confirmation in my email inbox"
 
-      confirmation_email_notification = wait_for_notification(expected_confirmation_mail_reference)
+      confirmation_email_notification = wait_for_notification(confirmation_email_reference)
     end
   end
 

--- a/spec/support/notify_helpers.rb
+++ b/spec/support/notify_helpers.rb
@@ -1,0 +1,36 @@
+# frozen_string_literal: true
+
+require_relative '../../services/notify_service'
+
+module NotifyHelpers
+  def get_confirmation_from_notify(expected_mail_reference, confirmation_code: false)
+    email = NotifyService.new.get_email(expected_mail_reference)
+
+    start_time = Time.now
+    logger.debug "Waiting 3sec for mail delivery to do its thing."
+    sleep 3
+    try = 0
+    while(Time.now - start_time < 5000) do
+      try += 1
+
+      if confirmation_code
+        unless email.collection.first.body.nil?
+          code = email.collection.first.body.match(/\d{6}/).to_s
+          logger.debug "Received the following code from Notify: “#{code}“"
+          return code
+        end
+      else
+        unless email.collection.first.status.nil?
+          status = email.collection.first.status
+          logger.debug "Received the following status from Notify: “#{status}“"
+          return email.collection.first
+        end
+      end
+
+      wait_time = try + ((Time.now - start_time) ** 0.5)
+      logger.debug 'failed. Sleeping %0.2fs.' % wait_time
+      sleep wait_time
+    end
+    return false
+  end
+end

--- a/spec/support/notify_helpers.rb
+++ b/spec/support/notify_helpers.rb
@@ -3,6 +3,10 @@
 require_relative '../../services/notify_service'
 
 module NotifyHelpers
+  def find_notification_reference(id)
+    page.find("##{id}", visible: false).value
+  end
+
   def wait_for_notification(notification_reference)
     email = NotifyService.new.get_email(notification_reference)
 


### PR DESCRIPTION
### What problem does this pull request solve?

Trello card: https://trello.com/c/SSMzBdHj/1338-improve-logging-of-notify-calls-in-forms-runner <!-- link -->

<!-- Add some description here about what the PR is about, even if you have a Trello card to link to -->

PR alphagov/forms-runner#634 renames the submission email reference ID to be less ambiguous. This PR makes the same change to the end to end tests.

We also do some refactoring of the code related to notifications and notification references.

This PR should be deployed after alphagov/forms-runner#634.

### Things to consider when reviewing

<!-- If this section isn't relevant for your PR feel free to edit or remove it -->

- Ensure that you consider the wider context.
- Does it work when run on your machine?
- Is it clear what the code is doing?
- Do the commit messages explain why the changes were made?
- Has all relevant documentation been updated?