### PR TITLE
Update Gemfile to use file reference for Ruby version

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,6 +1,6 @@
 source "https://rubygems.org"
 
-ruby "3.2.2"
+ruby file: ".ruby-version"
 
 gem "debug"
 gem "rspec"


### PR DESCRIPTION
### What problem does this pull request solve?

This means we only have 1 file to update (and means I can update this [script](https://github.com/alphagov/forms-deploy/blob/main/support/update_app_versions.sh#L70) to not bother with updating the Gemfile)

### Things to consider when reviewing

- Does it work when run on your machine?
- Is it clear what the code is doing?
- Do the commit messages explain why the changes were made?
