### PR TITLE
Add copies of spec files for backwards compatibility

### DIFF
--- a/spec/features/complete_spec.rb
+++ b/spec/features/complete_spec.rb
@@ -1,0 +1,50 @@
+feature "Full lifecycle of a form", type: :feature do
+  let(:test_email_address) { "govuk-forms-automation-tests@digital.cabinet-office.gov.uk" }
+
+  let(:form_name) { "capybara test form #{Time.now().strftime("%Y-%m-%d %H:%M.%S")}" }
+  let(:selection_question) { "Do you want to remain anonymous?" }
+  let(:question_text) { "What is your name?" }
+  let(:answer_text) { "test name" }
+  let(:start_url) do
+    if skip_product_pages?
+      forms_admin_url
+    else
+      product_pages_url
+    end
+  end
+
+  before do
+    Capybara.app_host = start_url
+  end
+
+  scenario "Form is created, made live by form admin user and completed by a member of the public" do
+    logger.info
+    logger.info "Scenario: Form is created, made live by form admin user"
+
+    unless bypass_end_to_end_tests('forms-admin', '/')
+      start_tracing
+
+      build_a_new_form
+
+      logger.info("Then I can share the live form")
+      live_form_link = page.find('[data-copy-target]').text
+
+      unless bypass_end_to_end_tests('forms-runner', live_form_link)
+        # Testing alternate routes (basic routing with a skip question)
+        logger.info "Scenario: Form is completed by a member of the public, and they answer all questions"
+        form_is_filled_in_by_form_filler(live_form_link, skip_question: false)
+
+        logger.info
+        logger.info "Scenario: Form is completed by a member of the public, and they use a route that skips questions"
+        form_is_filled_in_by_form_filler(live_form_link, skip_question: true)
+
+        # Testing confirmation email
+        logger.info
+        logger.info "Scenario: Form is completed by a member of the public, and they request a confirmation email"
+        form_is_filled_in_by_form_filler(live_form_link, confirmation_email: test_email_address)
+      end
+
+      delete_form
+    end
+  end
+end

--- a/spec/features/complete_spec.rb
+++ b/spec/features/complete_spec.rb
@@ -1,1 +1,0 @@
-../end_to_end/end_to_end_spec.rb

--- a/spec/features/smoke_test_runner_spec.rb
+++ b/spec/features/smoke_test_runner_spec.rb
@@ -1,0 +1,42 @@
+# frozen_string_literal: true
+
+feature 'Runner Smoke Test', type: :feature do
+  let(:smoke_test_form_url) do
+    ENV.fetch('SMOKE_TEST_FORM_URL') { raise 'You must set $SMOKE_TEST_FORM_URL' }
+  end
+
+  before do
+    Capybara.app_host = smoke_test_form_url
+  end
+
+  scenario 'Complete and submit an existing form' do
+    logger.info "Visiting #{smoke_test_form_url}"
+    visit smoke_test_form_url
+
+    expect(question_to_be_answered?).to be true
+
+    question_number = 1
+    while question_to_be_answered?
+      current_page = page.current_url
+      logger.info "#{current_page} answering question: #{question_number}"
+
+      question_type = page.first('input')[:name]
+      fill_in(class: 'govuk-input', with: answer_for(question_type))
+      click_button 'Continue'
+
+      expect(page).to have_no_content('There is a problem')
+      expect(page.current_url).not_to eq(current_page), "On the same page after clicking 'Continue'"
+
+      question_number += 1
+    end
+
+    logger.info 'Confirming answers'
+    expect(page).to have_content('Check your answers before submitting your form')
+
+    choose 'No', visible: false
+    click_button 'Submit'
+    logger.info 'Submitted answers'
+    expect(page).to have_content('Your form has been submitted')
+    logger.info 'Test complete'
+  end
+end

--- a/spec/features/smoke_test_runner_spec.rb
+++ b/spec/features/smoke_test_runner_spec.rb
@@ -1,1 +1,0 @@
-../smoke_tests/smoke_test_runner_spec.rb


### PR DESCRIPTION
### What problem does this pull request solve?

<!-- Add some description here about what the PR is about, even if you have a Trello card to link to -->

Our pipelines in the forms-deploy repo are hardcoded to use the old complete_spec.rb/smoke_test*.rb spec files, renaming them will cause them to break.

We tried to fix this with symlinks in commit 10a59096736, but we forgot that CodeBuild doesn't checkout symlinks [[1]]. Instead this commit just makes copies of the spec files.
### Things to consider when reviewing

<!-- If this section isn't relevant for your PR feel free to edit or remove it -->

- Ensure that you consider the wider context.
- Does it work when run on your machine?
- Is it clear what the code is doing?
- Do the commit messages explain why the changes were made?
- Has all relevant documentation been updated?