### PR TITLE
Replace element selector

### DIFF
--- a/spec/support/feature_helpers.rb
+++ b/spec/support/feature_helpers.rb
@@ -269,7 +269,7 @@ module FeatureHelpers
       if confirmation_email
         logger.info "And I can request a confirmation email"
         choose "Yes", visible: false
-        fill_in "email_confirmation_form[confirmation_email_address]", with: confirmation_email
+        fill_in "What email address do you want us to send your confirmation to?", with: confirmation_email
         confirmation_email_reference = find_notification_reference("confirmation-email-reference")
       else
         choose "No", visible: false


### PR DESCRIPTION
Replace a selector for selecting an input to fill in to use the label text instead of the element name, so that it is possible to change the name of the element in forms-runner.