### PR TITLE
Raise errors instead of aborting

### DIFF
--- a/spec/support/notify_helpers.rb
+++ b/spec/support/notify_helpers.rb
@@ -18,7 +18,7 @@ module NotifyHelpers
       return email.collection.first
     end
 
-    abort("ABORT!!! #{notification_reference} could not be found in Notify!!!")
+    raise "ABORT!!! #{notification_reference} could not be found in Notify!!!"
   end
 
   def wait_for_confirmation_code(notification_reference)


### PR DESCRIPTION
### What problem does this pull request solve?

<!-- Add some description here about what the PR is about, even if you have a Trello card to link to -->

Using `abort` in RSpec tests circumvents the systems used to detect
whether a test has failed, meaning that the output can end up being
slightly confusing and saying there were 0 failures:

```
Full lifecycle of a form
ABORT!!! 4d0b85b3-5163-4de9-bdca-111627072603 could not be found in Notify!!!

Finished in 15.79 seconds (files took 3.52 seconds to load)
1 example, 0 failures
```

This commit changes the uses of `abort` to `raise`, so that the RSpec
test runner can catch the error and record the failure as expected.

### Things to consider when reviewing

<!-- If this section isn't relevant for your PR feel free to edit or remove it -->

- Ensure that you consider the wider context.
- Does it work when run on your machine?
- Is it clear what the code is doing?
- Do the commit messages explain why the changes were made?
- Has all relevant documentation been updated?