### PR TITLE
Make e2e tests pass with group feature

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,6 +33,8 @@ Ensure both the forms-admin and forms-runner services are also configured to use
 
 ### Running the tests locally
 
+The tests expect an active group to exist called "End to end tests", which the test user belongs as a group admin. This name can be overridden by setting the environment variable `GROUP_NAME`.
+
 You can run the tests against localhost using the following command:
 
 ```
@@ -106,6 +108,14 @@ To enable tracing, set the `TRACE` environment variable:
 ```bash
 TRACE=1 bundle exec rspec
 ```
+
+### Setup in new environments
+
+The tests expect an editor user exist with an Auth0 database connection configured and a username and password set.
+
+The user should belong to an active group, called "End to end tests", as a group admin to allow publishing a form.
+
+The login details should be stored in AWS parameter store. See bin/load_env_vars.sh for configuring the enviroment varibles required.
 
 ### Changing Auth0 connection
 

--- a/spec/end_to_end/end_to_end_spec.rb
+++ b/spec/end_to_end/end_to_end_spec.rb
@@ -44,6 +44,8 @@ feature "Full lifecycle of a form", type: :feature do
         form_is_filled_in_by_form_filler(live_form_link, confirmation_email: test_email_address)
       end
 
+      visit_admin
+      visit_group_if_groups_feature_enabled
       delete_form
     end
   end


### PR DESCRIPTION
# Make e2e tests pass with group feature

Trello card: https://trello.com/c/quDifeT4/1550-migration-ensure-the-end-to-end-tests-pass-with-groups-feature-both-enabled-and-disabled

The end to end tests will fail if the groups feature is enabled.

The groups feature changes the start of the journey.

To fix the tests, they must visit an existing, active group before creating and deleting a form.

This commit adds a new method to visit the group, called "End to end tests" and continues the journey from there.

A few assertions about the URL have been removed as they are no longer true and are not needed.


### Things to consider when reviewing

<!-- If this section isn't relevant for your PR feel free to edit or remove it -->

- Ensure that you consider the wider context.
- Does it work when run on your machine?
- Is it clear what the code is doing?
- Do the commit messages explain why the changes were made?
- Has all relevant documentation been updated?
