### PR TITLE
Make tests pass when repeatable_page_enabled is true

### DIFF
--- a/spec/support/feature_helpers.rb
+++ b/spec/support/feature_helpers.rb
@@ -127,6 +127,11 @@ module FeatureHelpers
     click_button "Continue"
 
     expect(page.find("h1")).to have_content 'Edit question'
+
+    if page.has_field?("pages_question_input[is_repeatable]", type: :radio, visible: :all)
+      choose("No", name: "pages_question_input[is_repeatable]", visible: :all)
+    end
+
     click_button "Save question"
   end
 
@@ -144,6 +149,9 @@ module FeatureHelpers
     expect(page.find("h1")).to have_content 'Edit question'
     fill_in "Question text", :with => question_text
     choose "Mandatory", visible: false
+    if page.has_field?("pages_question_input[is_repeatable]", type: :radio, visible: :all)
+      choose("No", name: "pages_question_input[is_repeatable]", visible: :all)
+    end
     click_button "Save question"
 
   end


### PR DESCRIPTION
### What problem does this pull request solve?

When the feature flag for repeating pages is enabled the end to end test
will fail when creating new pages.

This is because the feature flag enables a new radio input for allowing
multiple answers to a question. This input must be completed for the
page to be saved.

Currently the tests fail when the hit this point, so would fail in
environments where the flag is on.

This PR adds checks for the input when creating new pages for selection
and single line of text questions. When the input is present, it chooses
no. This ensures that the form filler part doesn't need to change.

The test is:

```ruby
page.has_field?("pages_question_input[is_repeatable]", type: :radio, visible: :all)
```

We need to use `visible: :all` or `false` because labels for radio
buttons in the govuk design system hide the original inputs, so for
capybara they are not visible.

The check is in two places and could be extracted to a method.

It's been inlined because it's only two places and it keeps the context
clear.

