### PR TITLE
Add share preview task

### DIFF
--- a/spec/support/feature_helpers.rb
+++ b/spec/support/feature_helpers.rb
@@ -86,6 +86,16 @@ module FeatureHelpers
     fill_in "Enter the email address", with: test_email_address
     click_button "Save and continue"
 
+    # mark share preview task as completed if it is present
+    # TODO: remove this conditional once the feature has been deployed through the environments
+    if page.has_content? 'Share a preview of your draft form'
+      next_form_creation_step 'Share a preview of your draft form'
+
+      expect(page.find("h1")).to have_content "Share a preview of your draft form"
+      choose "Yes", visible: false
+      click_button "Save and continue"
+    end
+
     logger.info "And make it live"
     next_form_creation_step 'Make your form live'
 


### PR DESCRIPTION
### What problem does this pull request solve?

Trello card: <!-- link -->https://trello.com/c/QuqK5jmG/1867-add-new-task-to-share-a-preview-of-your-draft-form-for-drafts-of-new-live-and-archived-forms

<!-- Add some description here about what the PR is about, even if you have a Trello card to link to -->

As part of the above card we're adding a new mandatory task to the task list. This means that the current test will fail, since it doesn't complete the task.

This PR adds a new bit to the test that will check whether the new task is present and then fill it in. If the task isn't present, it will proceed to the make live task as usual. This is similar to the approach we used for testing the groups feature.

Should be merged in before https://github.com/alphagov/forms-api/pull/599 to avoid test failures. After that has been merged and deployed, we can remove the condition from the test so that the task will always be filled out.

### Things to consider when reviewing

<!-- If this section isn't relevant for your PR feel free to edit or remove it -->

- Ensure that you consider the wider context.
- Does it work when run on your machine?
- Is it clear what the code is doing?
- Do the commit messages explain why the changes were made?
- Has all relevant documentation been updated?
