### PR TITLE
Remove conditional added for share preview

### DIFF
--- a/spec/support/feature_helpers.rb
+++ b/spec/support/feature_helpers.rb
@@ -86,15 +86,11 @@ module FeatureHelpers
     fill_in "Enter the email address", with: test_email_address
     click_button "Save and continue"
 
-    # mark share preview task as completed if it is present
-    # TODO: remove this conditional once the feature has been deployed through the environments
-    if page.has_content? 'Share a preview of your draft form'
-      next_form_creation_step 'Share a preview of your draft form'
+    next_form_creation_step 'Share a preview of your draft form'
 
-      expect(page.find("h1")).to have_content "Share a preview of your draft form"
-      choose "Yes", visible: false
-      click_button "Save and continue"
-    end
+    expect(page.find("h1")).to have_content "Share a preview of your draft form"
+    choose "Yes", visible: false
+    click_button "Save and continue"
 
     logger.info "And make it live"
     next_form_creation_step 'Make your form live'


### PR DESCRIPTION
### What problem does this pull request solve?

Trello card: <!-- link -->https://trello.com/c/QuqK5jmG/1867-add-new-task-to-share-a-preview-of-your-draft-form-for-drafts-of-new-live-and-archived-forms

<!-- Add some description here about what the PR is about, even if you have a Trello card to link to -->
We added a conditional to the test so that it would work whether or not the share preview task was present. We've now merged in the share preview work, so it will appear on all forms. This means we can safely remove the conditional since the task will always be present and we want the test to fail if this isn't the case.

### Things to consider when reviewing

<!-- If this section isn't relevant for your PR feel free to edit or remove it -->

- Ensure that you consider the wider context.
- Does it work when run on your machine?
- Is it clear what the code is doing?
- Do the commit messages explain why the changes were made?
- Has all relevant documentation been updated?
