### PR TITLE
Fix tests for new route page

### DIFF
--- a/spec/support/feature_helpers.rb
+++ b/spec/support/feature_helpers.rb
@@ -174,6 +174,10 @@ module FeatureHelpers
     select "Yes", from: "is answered as"
     select "Check your answers before submitting", from: "take the person to"
     click_button "Save and continue"
+
+    if page.find("h1").has_content? /Question \d+’s routes/
+      click_link("Back to your questions", match: :first)
+    end
   end
 
   def mark_pages_task_complete


### PR DESCRIPTION
Trello card: https://trello.com/c/rwu6TDHu/1923-add-new-edit-routes-page

This commit to the admin changes the user journey for adding routes to a question.

This breaks the end to end tests because it doesn't expect this page to be there.

This commit adds a check to the end to end tests to ensure if the page is shown the user is returned to page list so the tests can continue as normal.

This is conditional so that the tests work both with the new page and without so that the change can be deployed.

### What problem does this pull request solve?



<!-- Add some description here about what the PR is about, even if you have a Trello card to link to -->

### Things to consider when reviewing

<!-- If this section isn't relevant for your PR feel free to edit or remove it -->

- Ensure that you consider the wider context.
- Does it work when run on your machine?
- Is it clear what the code is doing?
- Do the commit messages explain why the changes were made?
- Has all relevant documentation been updated?
