### PR TITLE
Pass s3 e2e test environment variables to dockerfile_test.sh

### DIFF
--- a/bin/dockerfile_test.sh
+++ b/bin/dockerfile_test.sh
@@ -1,4 +1,5 @@
 #!/bin/bash
+set -euo pipefail
 
 function help() {
   echo "Optionally builds the docker image and runs the tests against the development enviroment.
@@ -38,12 +39,21 @@ if [ -z "$FORMS_ADMIN_URL" ] || \
 fi
 
 echo 'Running the tests against dev environment'
-docker run --rm \
+
+env | grep AWS_ > ./env.list
+
+docker run --env-file ./env.list --rm \
   -e FORMS_ADMIN_URL \
   -e PRODUCT_PAGES_URL \
   -e AUTH0_EMAIL_USERNAME \
   -e AUTH0_USER_PASSWORD \
   -e SETTINGS__GOVUK_NOTIFY__API_KEY \
   -e SMOKE_TEST_FORM_URL \
+  -e FORMS_RUNNER_URL \
+  -e S3_FORM_ID \
+  -e AWS_S3_BUCKET \
+  -e SETTINGS__AWS_S3_SUBMISSIONS__IAM_ROLE_ARN \
+  -e AWS_REGION \
   "$IMAGE_TO_TEST"
 
+rm -f ./env.list


### PR DESCRIPTION
### What problem does this pull request solve?

dockerfile_test.sh is used in the e2e-image pipeline. In order to run the new s3 e2e tests, we need to pass in the relevant environment variables.

In order to pass in all aws related default variables to docker, we run `env | grep AWS_ > ./env.list`, which takes all env vars which contain `AWS_` and puts them into a file, this file is then passed to docker with `--env-file ./env.list`

[Trello card](https://trello.com/c/64CM50hZ/1921-add-an-e2e-test-for-s3-submissions)

<!-- Add some description here about what the PR is about, even if you have a Trello card to link to -->

### Things to consider when reviewing

<!-- If this section isn't relevant for your PR feel free to edit or remove it -->

- Ensure that you consider the wider context.
- Does it work when run on your machine?
- Is it clear what the code is doing?
- Do the commit messages explain why the changes were made?
- Has all relevant documentation been updated?
