### PR TITLE
Remove old page title for add a route from a question page

### DIFF
--- a/spec/support/feature_helpers.rb
+++ b/spec/support/feature_helpers.rb
@@ -168,7 +168,7 @@ module FeatureHelpers
     expect(page.find("h1")).to have_content 'Add and edit your questions'
     click_link "Add a question route"
 
-    expect(page.find("h1")).to have_content /(Add a question route)|(Add a route from a question)/ # TODO: remove second alternative after forms-admin#1617 has deployed to all environments
+    expect(page.find("h1")).to have_content "Add a route from a question"
     choose "1. #{selection_question}", visible: false
     click_button "Continue"
 


### PR DESCRIPTION
### What problem does this pull request solve?

Trello card: https://trello.com/c/uf5vIjGO/1968-update-guidance-content-on-the-add-a-route-from-a-question-page <!-- link -->

<!-- Add some description here about what the PR is about, even if you have a Trello card to link to -->

In commit 3ba1b70 we added the new title for this page alongside the old page title. Now that alphagov/forms-admin#1617 has been deployed everywhere we can remove the old page title.

### Things to consider when reviewing

<!-- If this section isn't relevant for your PR feel free to edit or remove it -->

- Ensure that you consider the wider context.
- Does it work when run on your machine?
- Is it clear what the code is doing?
- Do the commit messages explain why the changes were made?
- Has all relevant documentation been updated?