### PR TITLE
Add logic to use new selection journey if enabled

### DIFF
--- a/spec/support/feature_helpers.rb
+++ b/spec/support/feature_helpers.rb
@@ -128,11 +128,28 @@ module FeatureHelpers
     fill_in "What’s your question?", with: selection_question
     click_button "Continue"
 
-    expect(page.find("h1")).to have_content 'Create a list of options'
-    check "People can only select one option", visible: false
-    fill_in "Option 1", :with => "Yes"
-    fill_in "Option 2", :with => "No"
-    click_button "Continue"
+    if page.has_content? 'How many options should people be able to select?'
+      expect(page.find("h1")).to have_content 'How many options should people be able to select?'
+      choose "One option only", visible: false
+      click_button "Continue"
+
+      expect(page.find("h1")).to have_content 'Create a list of options'
+      fill_in "Option 1", :with => "Yes"
+      fill_in "Option 2", :with => "No"
+
+      within(page.find('fieldset', text: 'Should the list include an option for ‘None of the above’?')) do
+        choose "No", visible: false
+      end
+
+      click_button "Continue"
+    else
+      expect(page.find("h1")).to have_content 'Create a list of options'
+      check "People can only select one option", visible: false
+      fill_in "Option 1", :with => "Yes"
+      fill_in "Option 2", :with => "No"
+      click_button "Continue"
+    end
+
 
     expect(page.find("h1")).to have_content 'Edit question'
 


### PR DESCRIPTION
### What problem does this pull request solve?

Trello card: <!-- link -->https://trello.com/c/v9BZe6or/1998-25-nov-release-long-lists-with-autocomplete-for-all-departments

<!-- Add some description here about what the PR is about, even if you have a Trello card to link to -->
We've made some changes to the selection journey in forms-admin which break the current e2e tests. We've previously turned this journey change on in production, but only for selected groups (not the group we use for e2e tests).

As part of the linked trello card, we're going to turn the feature on in production for everyone (PR here: https://github.com/alphagov/forms-admin/pull/1623) so we need the tests to be able to handle the new journey - this PR does that. It should now handle both the existing journey and the new one.

We'll need to do another PR later (once we're happy with the new journey) to remove the old journey test logic.

### Things to consider when reviewing

<!-- If this section isn't relevant for your PR feel free to edit or remove it -->

- Ensure that you consider the wider context.
- Does it work when run on your machine?
- Is it clear what the code is doing?
- Do the commit messages explain why the changes were made?
- Has all relevant documentation been updated?
