### PR TITLE
Remove logic for handling old selection flow

### DIFF
--- a/spec/support/feature_helpers.rb
+++ b/spec/support/feature_helpers.rb
@@ -128,28 +128,19 @@ module FeatureHelpers
     fill_in "What’s your question?", with: selection_question
     click_button "Continue"
 
-    if page.has_content? 'How many options should people be able to select?'
-      expect(page.find("h1")).to have_content 'How many options should people be able to select?'
-      choose "One option only", visible: false
-      click_button "Continue"
+    expect(page.find("h1")).to have_content 'How many options should people be able to select?'
+    choose "One option only", visible: false
+    click_button "Continue"
 
-      expect(page.find("h1")).to have_content 'Create a list of options'
-      fill_in "Option 1", :with => "Yes"
-      fill_in "Option 2", :with => "No"
+    expect(page.find("h1")).to have_content 'Create a list of options'
+    fill_in "Option 1", :with => "Yes"
+    fill_in "Option 2", :with => "No"
 
-      within(page.find('fieldset', text: 'Should the list include an option for ‘None of the above’?')) do
-        choose "No", visible: false
-      end
-
-      click_button "Continue"
-    else
-      expect(page.find("h1")).to have_content 'Create a list of options'
-      check "People can only select one option", visible: false
-      fill_in "Option 1", :with => "Yes"
-      fill_in "Option 2", :with => "No"
-      click_button "Continue"
+    within(page.find('fieldset', text: 'Should the list include an option for ‘None of the above’?')) do
+      choose "No", visible: false
     end
 
+    click_button "Continue"
 
     expect(page.find("h1")).to have_content 'Edit question'
 


### PR DESCRIPTION
### What problem does this pull request solve?

Trello card: <!-- link -->https://trello.com/c/BFWKD1ZG/2541-clean-up-after-long-lists-work

<!-- Add some description here about what the PR is about, even if you have a Trello card to link to -->
In the helper for adding a selection question, we previously added a condition for checking which selection journey was in use and proceeding handling the different question flows.

We've now removed the old selection journey from forms-admin, so we can remove the check and the code for the old journey.

*Do not merge* until we're happy we won't turn the new selection journey off.

### Things to consider when reviewing

<!-- If this section isn't relevant for your PR feel free to edit or remove it -->

- Ensure that you consider the wider context.
- Does it work when run on your machine?
- Is it clear what the code is doing?
- Do the commit messages explain why the changes were made?
- Has all relevant documentation been updated?
