### PR TITLE
Rename aws iam role env var

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,7 +61,7 @@ You will need:
 To run the tests:
 
 - in `forms-runner`: 
-    - add your govuk_notify.api_key and aws_s3_submissions.iam_role_arn to settings.local.yml
+    - add your govuk_notify.api_key and aws.s3_submission_iam_role to settings.local.yml
     - start the server using an iam role that can assume the above role (eg: `gds aws forms-dev-readonly -- bundle exec rails s`)
 - in `forms-admin` 
     - add your govuk_notify.api_key to settings.local.yml
@@ -82,7 +82,7 @@ SKIP_PRODUCT_PAGES=1 \
 LOG_LEVEL=info \
 SETTINGS__GOVUK_NOTIFY__API_KEY= ${ your notify api key here } \
 FORMS_RUNNER_URL='http://localhost:3001/' \
-SETTINGS__AWS_S3_SUBMISSIONS__IAM_ROLE_ARN= ${ the iam role arn } \
+SETTINGS__AWS__S3_SUBMISSION_IAM_ROLE_ARN= ${ the iam role arn } \
 AWS_S3_BUCKET=${ the name of the s3 bucket } \
 S3_FORM_ID='2' \
 bundle exec rspec spec/end_to_end

--- a/bin/dockerfile_test.sh
+++ b/bin/dockerfile_test.sh
@@ -51,9 +51,6 @@ docker run --env-file ./env.list --rm \
   -e SMOKE_TEST_FORM_URL \
   -e FORMS_RUNNER_URL \
   -e S3_FORM_ID \
-  -e AWS_S3_BUCKET \
-  -e SETTINGS__AWS_S3_SUBMISSIONS__IAM_ROLE_ARN \
-  -e AWS_REGION \
   "$IMAGE_TO_TEST"
 
 rm -f ./env.list

--- a/spec/support/aws_helpers.rb
+++ b/spec/support/aws_helpers.rb
@@ -19,9 +19,9 @@ module AwsHelpers
   end
 
   def assume_role
-    @role_arn = ENV['SETTINGS__AWS_S3_SUBMISSIONS__IAM_ROLE_ARN']
+    @role_arn = ENV['SETTINGS__AWS__S3_SUBMISSION_IAM_ROLE_ARN']
 
-    raise 'You must set SETTINGS__AWS_S3_SUBMISSIONS__IAM_ROLE_ARN' if @role_arn.nil? || @role_arn.empty?
+    raise 'You must set SETTINGS__AWS__S3_SUBMISSION_IAM_ROLE_ARN' if @role_arn.nil? || @role_arn.empty?
 
     role_session_name = 'forms-e2e'
     Aws::AssumeRoleCredentials.new(


### PR DESCRIPTION
### What problem does this pull request solve?

[Trello card](https://trello.com/c/snn0svAW/2052-rename-awss3submissions-runner-setting)

This PR renames `SETTINGS__AWS_S3_SUBMISSIONS__IAM_ROLE_ARN` to `SETTINGS__AWS__S3_SUBMISSION_IAM_ROLE_ARN`. This is to match the structure of the settings.yml file in forms-runner.

This PR also removes the passing in off three env vars to the docker image to test. This is because these three envs are already being passed in with the ./env.list file which is looking for all env with `AWS_`

I've tested this against the e2e pipeline and it's all working

### Things to consider when reviewing

<!-- If this section isn't relevant for your PR feel free to edit or remove it -->

- Ensure that you consider the wider context.
- Does it work when run on your machine?
- Is it clear what the code is doing?
- Do the commit messages explain why the changes were made?
- Has all relevant documentation been updated?
