### PR TITLE
Fix end to end tests for alphagov/forms-admin#1777

### DIFF
--- a/spec/support/feature_helpers.rb
+++ b/spec/support/feature_helpers.rb
@@ -182,7 +182,7 @@ module FeatureHelpers
 
     expect(page.find("h1")).to have_content 'Add a question route'
     select "Yes", from: "is answered as"
-    select "Check your answers before submitting", from: "take the person to"
+    select "Check your answers before submitting", from: "to"
     click_button "Save and continue"
 
     if page.find("h1").has_content? /Question \d+’s routes/


### PR DESCRIPTION
### What problem does this pull request solve?

<!-- Add some description here about what the PR is about, even if you have a Trello card to link to -->

The label text for the `goto_page_id` select was changed in alphagov/forms-admin#1777; this commit updates the end to end tests to work with either the old or new label text.

### Things to consider when reviewing

<!-- If this section isn't relevant for your PR feel free to edit or remove it -->

- Ensure that you consider the wider context.
- Does it work when run on your machine?
- Is it clear what the code is doing?
- Do the commit messages explain why the changes were made?
- Has all relevant documentation been updated?