### PR TITLE
Update heading for add route page

### DIFF
--- a/spec/support/feature_helpers.rb
+++ b/spec/support/feature_helpers.rb
@@ -180,7 +180,7 @@ module FeatureHelpers
     choose "1. #{selection_question}", visible: false
     click_button "Continue"
 
-    expect(page.find("h1")).to have_content 'Add a question route'
+    expect(page.find("h1")).to have_content /(Add a question route|Add route)/
     select "Yes", from: "is answered as"
     select "Check your answers before submitting", from: "to"
     click_button "Save and continue"


### PR DESCRIPTION
### What problem does this pull request solve?

Trello card: https://trello.com/c/faPNxjxY/2133-update-routing-pages-to-match-designs-snags-ticket <!-- link -->

<!-- Add some description here about what the PR is about, even if you have a Trello card to link to -->

The heading for the add route page was changed in alphagov/forms-admin#1785, this commit updates the end to end tests to work with either the old or new heading text.


### Things to consider when reviewing

<!-- If this section isn't relevant for your PR feel free to edit or remove it -->

- Ensure that you consider the wider context.
- Does it work when run on your machine?
- Is it clear what the code is doing?
- Do the commit messages explain why the changes were made?
- Has all relevant documentation been updated?