### PR TITLE
Change Docker image to use older version of Chromium

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,8 @@
-ARG ALPINE_VERSION=3.21
+# TODO: restore to latest version of Alpine once we can use the latest Chromium again (see https://github.com/teamcapybara/capybara/issues/2800)
+ARG ALPINE_VERSION=3.20
 ARG RUBY_VERSION=3.4.1
 
-ARG DOCKER_IMAGE_DIGEST=sha256:e5c30595c6a322bc3fbaacd5e35d698a6b9e6d1079ab0af09ffe52f5816aec3b
+ARG DOCKER_IMAGE_DIGEST=sha256:d799fbab7da903c8e709be7df0734b8593ef884242cd34b7a7369b527f06aec3
 
 FROM ruby:${RUBY_VERSION}-alpine${ALPINE_VERSION}@${DOCKER_IMAGE_DIGEST}
 


### PR DESCRIPTION
### What problem does this pull request solve?

<!-- Add some description here about what the PR is about, even if you have a Trello card to link to -->

We are seeing intermittent failures when end to end tests are run locally. These failures are related to Selenium and chromedriver 134 [[1]]. They are false positives and do not mean the code is broken.

We want to make sure we don't have these issues with our end to end tests and smoke tests in AWS. So far this hasn't happened, because our Docker image hasn't been rebuilt recently, but the next time the image is rebuilt we will start seeing failures, as the Alpine 3.21 release branch has recently been updated with the latest version of Chromium.

This commit makes sure we won't get the affected version of Chromium/chromedriver in our end to end test Docker image by rolling back the base image to the previous release branch of Alpine Linux. This branch has an older version of Chromium and chromedriver [[2]] which does not have these issues with Selenium, and because chromium is in the community repository it won't be updated in the 3.20 release branch unless there is an security fix.

Using the older release branch is preferable to just sticking with the Docker image that we have now, because then we still get the benefit of security fixes and patches to packages in the main repository.

[1]: https://github.com/teamcapybara/capybara/issues/2800
[2]: https://pkgs.alpinelinux.org/packages?name=chromium*&branch=v3.20&repo=&arch=x86_64&origin=&flagged=&maintainer=


### Things to consider when reviewing

<!-- If this section isn't relevant for your PR feel free to edit or remove it -->

- Ensure that you consider the wider context.
- Does it work when run on your machine?
- Is it clear what the code is doing?
- Do the commit messages explain why the changes were made?
- Has all relevant documentation been updated?