### PR TITLE
Fix E2E tests for current and previous content

### DIFF
--- a/spec/support/feature_helpers.rb
+++ b/spec/support/feature_helpers.rb
@@ -181,7 +181,13 @@ module FeatureHelpers
     click_button "Continue"
 
     expect(page.find("h1")).to have_content /(Add a question route|Add route)/
-    select "Yes", from: "If the answer selected is"
+
+    if page.has_content? /is answered as/
+      select "Yes", from: "is answered as"
+    else
+      select "Yes", from: "If the answer selected is"
+    end
+
     select "Check your answers before submitting", from: "to"
     click_button "Save and continue"
 


### PR DESCRIPTION
The end-to-end tests can't build because the content in admin has changed.

This change ensures they pass with the previous version of admin and the current one.

This commit can be reverted when the new code is deployed and the tests have passed.

### What problem does this pull request solve?

Trello card: <!-- link -->

<!-- Add some description here about what the PR is about, even if you have a Trello card to link to -->

### Things to consider when reviewing

<!-- If this section isn't relevant for your PR feel free to edit or remove it -->

- Ensure that you consider the wider context.
- Does it work when run on your machine?
- Is it clear what the code is doing?
- Do the commit messages explain why the changes were made?
- Has all relevant documentation been updated?
