### PR TITLE
Add environment variable to skip file upload test

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,7 +52,7 @@ The end to end tests can be run without testing a form with the `submission_type
 
 ### Skipping the file upload
 
-It's a separate test scenario so you can run that in the usual rspec way by line number, i.e. `bundle exec rspec spec/end_to_end/end_to_end_spec.rb:123`. So you can run the main scenario to skip, and conversely you can run the file upload scenario in isolation.
+The end to end tests can be run without testing a form with a file upload question by setting the `SKIP_FILE_UPLOAD` environment variable to `1`.
 
 ### Running the file upload test
 Forms-runner needs to be started with the AWS credentials for the dev account for the file upload test to pass, as follows:

--- a/Rakefile
+++ b/Rakefile
@@ -9,6 +9,7 @@ desc "Run end to end tests against local environment"
 RSpec::Core::RakeTask.new(:end_to_end) do |task|
   ENV["SKIP_AUTH"] ||= "1"
   ENV["SKIP_S3"] ||= "1"
+  ENV["SKIP_FILE_UPLOAD"] ||= "1"
   ENV["FORMS_ADMIN_URL"] ||= "http://localhost:3000/"
   ENV["PRODUCT_PAGES_URL"] ||= "http://localhost:3002/"
 

--- a/spec/end_to_end/end_to_end_spec.rb
+++ b/spec/end_to_end/end_to_end_spec.rb
@@ -58,29 +58,31 @@ feature "Full lifecycle of a form", type: :feature do
     end
   end
 
-  context "when the form has a file upload" do
-    let(:file_question_text) { "Upload a file" }
-    let(:test_file) { "/tmp/temp-file.txt" }
+  unless ENV.fetch('SKIP_FILE_UPLOAD', false)
+    context "when the form has a file upload" do
+      let(:file_question_text) { "Upload a file" }
+      let(:test_file) { "/tmp/temp-file.txt" }
 
-    before do
-      File.write(test_file, "Hello file")
-    end
+      before do
+        File.write(test_file, "Hello file")
+      end
 
-    after do
-      File.delete(test_file) if File.exist?(test_file)
-    end
+      after do
+        File.delete(test_file) if File.exist?(test_file)
+      end
 
-    scenario "Form is created, made live by form admin user and completed by a member of the public with a file upload" do
-      start_tracing
+      scenario "Form is created, made live by form admin user and completed by a member of the public with a file upload" do
+        start_tracing
 
-      build_a_new_form_with_file_upload
+        build_a_new_form_with_file_upload
 
-      live_form_link = page.find('[data-copy-target]').text
-      upload_file_and_submit(live_form_link)
+        live_form_link = page.find('[data-copy-target]').text
+        upload_file_and_submit(live_form_link)
 
-      visit_admin
-      visit_group
-      delete_form
+        visit_admin
+        visit_group
+        delete_form
+      end
     end
   end
 end

--- a/spec/end_to_end/end_to_end_spec.rb
+++ b/spec/end_to_end/end_to_end_spec.rb
@@ -59,7 +59,7 @@ feature "Full lifecycle of a form", type: :feature do
   end
 
   unless ENV.fetch('SKIP_FILE_UPLOAD', false)
-    context "when the form has a file upload" do
+    context "when the form has a file upload question" do
       let(:file_question_text) { "Upload a file" }
       let(:test_file) { "/tmp/temp-file.txt" }
 


### PR DESCRIPTION
### What problem does this pull request solve?

<!-- Add some description here about what the PR is about, even if you have a Trello card to link to -->

Testing a form with file upload requires AWS credentials, which might not always be present. With other tests in this repo that needs particular setup we have environment variables to control whether the test is run; this commit makes the file upload test consistent with that.

We then use this environment variable to skip file upload tests when using `bin/rake`, keeping it so that you don't need AWS credentials to run the tests quickly.
### Things to consider when reviewing

<!-- If this section isn't relevant for your PR feel free to edit or remove it -->

- Ensure that you consider the wider context.
- Does it work when run on your machine?
- Is it clear what the code is doing?
- Do the commit messages explain why the changes were made?
- Has all relevant documentation been updated?