### PR TITLE
Add env vars for file upload end to end test to local script

### DIFF
--- a/bin/load_env_vars.sh
+++ b/bin/load_env_vars.sh
@@ -28,6 +28,20 @@ function product_pages_url() {
   esac
 }
 
+function runner_url() {
+  local environment="$1"
+
+  case $environment in
+    "dev") echo "https://submit.dev.forms.service.gov.uk" ;;
+    "staging") echo "https://submit.staging.forms.service.gov.uk" ;;
+    "production") echo "https://submit.forms.service.gov.uk" ;;
+    *)
+      echo "Unknown environment: ${environment}"
+      exit 1
+      ;;
+  esac
+}
+
 function form_url() {
   local environment="$1"
 
@@ -35,6 +49,49 @@ function form_url() {
     "dev") echo "https://submit.dev.forms.service.gov.uk/form/11120/scheduled-smoke-test" ;;
     "staging") echo "https://submit.staging.forms.service.gov.uk/form/12148/scheduled-smoke-test" ;;
     "production") echo "https://submit.forms.service.gov.uk/form/2570/scheduled-smoke-test" ;;
+    *)
+      echo "Unknown environment: ${environment}"
+      exit 1
+      ;;
+  esac
+}
+
+function aws_account_id() {
+  aws sts get-caller-identity --query Account --output text
+}
+
+function aws_s3_role_arn() {
+  local environment="$1"
+  local account_id="$(aws_account_id)"
+
+  case $environment in
+    "dev"|"staging"|"production") echo "arn:aws:iam::${account_id}:role/govuk-s3-end-to-end-test-${environment}" ;;
+    *)
+      echo "unknown environment: ${environment}"
+      exit 1
+      ;;
+  esac
+}
+
+function aws_s3_bucket() {
+  local environment="$1"
+
+  case $environment in
+    "dev"|"staging"|"production") echo "govuk-forms-submissions-to-s3-test" ;;
+    *)
+      echo "unknown environment: ${environment}"
+      exit 1
+      ;;
+  esac
+}
+
+function s3_form_id() {
+  local environment="$1"
+
+  case $environment in
+    "dev") echo "12457" ;;
+    "staging") echo "13657" ;;
+    "production") echo "5086" ;;
     *)
       echo "Unknown environment: ${environment}"
       exit 1
@@ -60,10 +117,14 @@ function set_e2e_env_vars() {
   fi
 
   export FORMS_ADMIN_URL="$(admin_url $environment)"
+  export FORMS_RUNNER_URL="$(runner_url $environment)"
   export PRODUCT_PAGES_URL="$(product_pages_url $environment)"
   export SETTINGS__GOVUK_NOTIFY__API_KEY="$(get_param /${environment}/automated-tests/e2e/notify/api-key)"
   export AUTH0_EMAIL_USERNAME="$(get_param /${environment}/automated-tests/e2e/auth0/email-username)"
   export AUTH0_USER_PASSWORD="$(get_param /${environment}/automated-tests/e2e/auth0/auth0-user-password)"
+  export S3_FORM_ID="$(s3_form_id $environment)"
+  export AWS_S3_BUCKET="$(aws_s3_bucket $environment)"
+  export SETTINGS__AWS__S3_SUBMISSION_IAM_ROLE_ARN="$(aws_s3_role_arn $environment)"
 }
 
 function set_smoke_test_env_vars() {


### PR DESCRIPTION
### What problem does this pull request solve?

<!-- Add some description here about what the PR is about, even if you have a Trello card to link to -->

The `bin/end_to_end.sh` script was no longer working completely, because the configuration needed to run the test of a form with file upload question was missing.

This commit adds the required environment variables to `bin/load_env_vars.sh`:

- FORMS_RUNNER_URL
- AWS_S3_BUCKET
- S3_FORM_ID
- SETTINGS__AWS_S3_SUBMISSION_IAM_ROLE_ARN

### Things to consider when reviewing

I've tested these changes against dev with `gds aws forms-dev-readonly -- bin/end_to_end.sh dev`

<!-- If this section isn't relevant for your PR feel free to edit or remove it -->

- Ensure that you consider the wider context.
- Does it work when run on your machine?
- Is it clear what the code is doing?
- Do the commit messages explain why the changes were made?
- Has all relevant documentation been updated?