### PR TITLE
Switch from Chromedriver to Cuprite

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -10,7 +10,7 @@ WORKDIR /app
 RUN apk update
 RUN apk upgrade --available
 
-RUN apk add chromium chromium-chromedriver libc6-compat build-base
+RUN apk add chromium libc6-compat build-base
 
 RUN adduser -D ruby
 USER ruby

--- a/Gemfile
+++ b/Gemfile
@@ -5,9 +5,8 @@ ruby file: ".ruby-version"
 gem "debug"
 gem "rspec"
 gem "capybara"
+gem "cuprite"
 gem "notifications-ruby-client"
-gem "selenium-webdriver"
-gem "webdrivers"
 gem "aws-sdk-s3", "~> 1.183"
 
 group :development, :test do

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -31,11 +31,20 @@ GEM
       rack-test (>= 0.6.3)
       regexp_parser (>= 1.5, < 3.0)
       xpath (~> 3.2)
+    concurrent-ruby (1.3.5)
+    cuprite (0.15.1)
+      capybara (~> 3.0)
+      ferrum (~> 0.15.0)
     date (3.4.1)
     debug (1.10.0)
       irb (~> 1.10)
       reline (>= 0.3.8)
     diff-lcs (1.5.1)
+    ferrum (0.15)
+      addressable (~> 2.5)
+      concurrent-ruby (~> 1.1)
+      webrick (~> 1.7)
+      websocket-driver (~> 0.7)
     io-console (0.8.0)
     irb (1.14.3)
       rdoc (>= 4.0.0)
@@ -76,7 +85,6 @@ GEM
     regexp_parser (2.9.0)
     reline (0.6.0)
       io-console (~> 0.5)
-    rexml (3.4.1)
     rspec (3.13.0)
       rspec-core (~> 3.13.0)
       rspec-expectations (~> 3.13.0)
@@ -90,19 +98,12 @@ GEM
       diff-lcs (>= 1.2.0, < 2.0)
       rspec-support (~> 3.13.0)
     rspec-support (3.13.0)
-    rubyzip (2.4.1)
-    selenium-webdriver (4.30.1)
-      base64 (~> 0.2)
-      logger (~> 1.4)
-      rexml (~> 3.2, >= 3.2.5)
-      rubyzip (>= 1.2.2, < 3.0)
-      websocket (~> 1.0)
     stringio (3.1.2)
-    webdrivers (5.2.0)
-      nokogiri (~> 1.6)
-      rubyzip (>= 1.3.0)
-      selenium-webdriver (~> 4.0)
-    websocket (1.2.11)
+    webrick (1.9.1)
+    websocket-driver (0.7.7)
+      base64
+      websocket-extensions (>= 0.1.0)
+    websocket-extensions (0.1.5)
     xpath (3.2.0)
       nokogiri (~> 1.8)
 
@@ -117,12 +118,11 @@ PLATFORMS
 DEPENDENCIES
   aws-sdk-s3 (~> 1.183)
   capybara
+  cuprite
   debug
   notifications-ruby-client
   rake
   rspec
-  selenium-webdriver
-  webdrivers
 
 RUBY VERSION
    ruby 3.4.1p0

--- a/README.md
+++ b/README.md
@@ -11,9 +11,7 @@ runner and then deletes the form.
 
 ### Install
 
-Make sure you have `chrome` and a matching version of `chromedriver` installed and in your path.
-
-You can follow [these instructions](https://chromedriver.chromium.org/getting-started) or download it directly from https://googlechromelabs.github.io/chrome-for-testing/
+Make sure you have `chrome`  installed and in your path.
 
 Install the ruby dependencies:
 

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,47 +1,19 @@
+require 'capybara/cuprite'
 require 'capybara/rspec'
-require 'selenium/webdriver'
 require 'debug'
 
 require_relative "support/feature_helpers"
 require_relative "support/logging"
 
-options = Selenium::WebDriver::Chrome::Options.new
-options.add_preference(:download, prompt_for_download: false,
-                                  default_directory: '/tmp/downloads')
-
-options.add_preference(:browser, set_download_behavior: { behavior: 'allow' })
-
-Capybara.register_driver :chrome do |app|
-  Capybara::Selenium::Driver.new(app, browser: :chrome, options: options)
+Capybara.register_driver(:cuprite) do |app|
+  Capybara::Cuprite::Driver.new(app, headless: false, browser_options: { "no-sandbox": nil })
 end
 
-Capybara.register_driver :headless_chrome do |app|
-  options.add_argument('--headless')
-  options.add_argument('--disable-gpu')
-  options.add_argument('--window-size=1280,1024')
-  options.add_argument('--no-sandbox')
-  options.add_argument('--disable-dev-shm-usage')
-
-  driver = Capybara::Selenium::Driver.new(app, browser: :chrome, options: options)
-
-  ### Allow file downloads in Google Chrome when headless!!!
-  ### https://bugs.chromium.org/p/chromium/issues/detail?id=696481#c89
-  bridge = driver.browser.send(:bridge)
-
-  path = '/session/:session_id/chromium/send_command'
-  path[':session_id'] = bridge.session_id
-
-  bridge.http.call(:post, path, cmd: 'Page.setDownloadBehavior',
-                                params: {
-                                  behavior: 'allow',
-                                  downloadPath: '/tmp/downloads'
-                                })
-  ###
-
-  driver
+Capybara.register_driver(:cuprite_headless) do |app|
+  Capybara::Cuprite::Driver.new(app, headless: true, browser_options: { "no-sandbox": nil })
 end
 
-Capybara.default_driver = ENV['GUI'] ? :chrome : :headless_chrome
+Capybara.default_driver = ENV['GUI'] ? :cuprite : :cuprite_headless
 
 Capybara.configure do |config|
   config.automatic_label_click = true

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -6,11 +6,11 @@ require_relative "support/feature_helpers"
 require_relative "support/logging"
 
 Capybara.register_driver(:cuprite) do |app|
-  Capybara::Cuprite::Driver.new(app, headless: false, browser_options: { "no-sandbox": nil })
+  Capybara::Cuprite::Driver.new(app, headless: false, browser_options: { "no-sandbox": nil }, options: { timeout: 20 })
 end
 
 Capybara.register_driver(:cuprite_headless) do |app|
-  Capybara::Cuprite::Driver.new(app, headless: true, browser_options: { "no-sandbox": nil })
+  Capybara::Cuprite::Driver.new(app, headless: true, browser_options: { "no-sandbox": nil }, options: { timeout: 20 })
 end
 
 Capybara.default_driver = ENV['GUI'] ? :cuprite : :cuprite_headless

--- a/spec/support/feature_helpers.rb
+++ b/spec/support/feature_helpers.rb
@@ -252,7 +252,7 @@ module FeatureHelpers
 
       expected_mail_reference = find_notification_reference("notification-id")
 
-      fill_in "What email address should completed forms be sent to?", with: test_email_address, fill_options: { clear: :backspace }
+      fill_in "What email address should completed forms be sent to?", with: test_email_address
       click_button "Save and continue"
 
       expect(page.find("h1")).to have_content 'Confirmation code sent'


### PR DESCRIPTION
### What problem does this pull request solve?

Cuprite is faster and runs more reliably. Chromedriver has an ongoing issue that we've had to mitigate by pinning to an older version for some of our apps. We can't switch to Cuprite for Runner and Admin as it's incompatible with `axe-core-rspec` so we can't run our accessibility tests with Cuprite there.

However, e2e tests take a while to run and run on every build. I've been using this branch for local development and it's sped up productivity for me massively.

Thank you @lfdebrux for this!

<!-- Add some description here about what the PR is about, even if you have a Trello card to link to -->

### Things to consider when reviewing

<!-- If this section isn't relevant for your PR feel free to edit or remove it -->

- Ensure that you consider the wider context.
- Does it work when run on your machine?
- Is it clear what the code is doing?
- Do the commit messages explain why the changes were made?
- Has all relevant documentation been updated?
