### PR TITLE
Make tests compatible with submission emails sent via AWS SES

### DIFF
--- a/bin/load_env_vars.sh
+++ b/bin/load_env_vars.sh
@@ -126,7 +126,6 @@ function set_e2e_env_vars() {
   export AWS_S3_BUCKET="$(aws_s3_bucket $environment)"
   export SETTINGS__AWS__S3_SUBMISSION_IAM_ROLE_ARN="$(aws_s3_role_arn $environment)"
   export SETTINGS__SUBMISSION_STATUS_API__SECRET="$(get_param /${environment}/automated-tests/e2e/runner/submission_status_api_shared_secret)"
-  export SES_SUBMISSIONS="$(ses_submissions_enabled $environment)"
 }
 
 function set_smoke_test_env_vars() {

--- a/spec/end_to_end/end_to_end_spec.rb
+++ b/spec/end_to_end/end_to_end_spec.rb
@@ -82,7 +82,7 @@ feature "Full lifecycle of a form", type: :feature do
         live_form_link = page.find('[data-copy-target]').text
         upload_file_and_submit(live_form_link)
 
-        check_file_upload_submission
+        check_submission
 
         visit_admin
         visit_end_to_end_tests_group

--- a/spec/end_to_end/end_to_end_spec.rb
+++ b/spec/end_to_end/end_to_end_spec.rb
@@ -62,7 +62,6 @@ feature "Full lifecycle of a form", type: :feature do
       let(:form_name) { "capybara test file upload form #{Time.now().strftime("%Y-%m-%d %H:%M.%S")}" }
       let(:file_question_text) { "Upload a file" }
       let(:test_file) { "/tmp/temp-file.txt" }
-      let (:status_api_url) { "#{ENV['FORMS_RUNNER_URL']}/submission" }
       let (:status_api_response) {}
       let (:submission_reference) {}
 

--- a/spec/support/feature_helpers.rb
+++ b/spec/support/feature_helpers.rb
@@ -36,6 +36,14 @@ module FeatureHelpers
     ENV.fetch('PRODUCT_PAGES_URL') { raise 'You must set $PRODUCT_PAGES_URL' }
   end
 
+  def forms_runner_url
+    ENV.fetch('FORMS_RUNNER_URL') { raise 'You must set $FORMS_RUNNER_URL' }
+  end
+
+  def submission_status_url
+    "#{forms_runner_url}/submission"
+  end
+
   def build_a_new_form
     logger.info
     logger.info 'As an editor user'
@@ -402,7 +410,7 @@ module FeatureHelpers
   def check_submission
     submission_reference = page.find('#submission-reference').text
 
-    uri = URI(status_api_url)
+    uri = URI(submission_status_url)
     uri.query = URI.encode_www_form(reference: submission_reference)
 
     request = Net::HTTP::Get.new(uri)
@@ -430,9 +438,8 @@ module FeatureHelpers
   end
 
   def s3_form_is_filled_in_by_form_filler()
-    runner_url =  ENV.fetch('FORMS_RUNNER_URL') { raise 'You must set $FORMS_RUNNER_URL' }
     form_id =  ENV.fetch('S3_FORM_ID') { raise 'You must set $S3_FORM_ID' }
-    s3_form_live_link = runner_url + '/form/' + form_id
+    s3_form_live_link = forms_runner_url + '/form/' + form_id
 
     logger.info
     logger.info "As a form filler"

--- a/spec/support/feature_helpers.rb
+++ b/spec/support/feature_helpers.rb
@@ -399,7 +399,7 @@ module FeatureHelpers
     expect(page).to have_content "Your form has been submitted"
   end
 
-  def check_file_upload_submission
+  def check_submission
     submission_reference = page.find('#submission-reference').text
 
     uri = URI(status_api_url)

--- a/spec/support/notify_helpers.rb
+++ b/spec/support/notify_helpers.rb
@@ -3,6 +3,9 @@
 require_relative '../../services/notify_service'
 
 module NotifyHelpers
+
+  class NotifyException < RuntimeError; end
+
   def find_notification_reference(id)
     page.find("##{id}", visible: false).value
   end
@@ -10,15 +13,13 @@ module NotifyHelpers
   def wait_for_notification(notification_reference)
     email = NotifyService.new.get_email(notification_reference)
 
-    logger.debug "Waiting 3sec for mail delivery to do its thing."
-
     if email.collection && email.collection.first && email.collection.first.status
       status = email.collection.first.status
       logger.debug "Received the following status from Notify: #{status}"
       return email.collection.first
     end
 
-    raise "ABORT!!! #{notification_reference} could not be found in Notify!!!"
+    raise NotifyException, "ABORT!!! #{notification_reference} could not be found in Notify!!!"
   end
 
   def wait_for_confirmation_code(notification_reference)


### PR DESCRIPTION
### What problem does this pull request solve?

Trello card: https://trello.com/c/dcOt4eaV

This PR adds a NotifyException to NotifyHelpers, which is then used in the tests to attempt submission via SES if mails cannot be found in Notify. This means it is possible for the end-to-end tests to work with submission emails sent via either Notify or AWS SES. Notify is attempted first as this is the existing behaviour.

I've also renamed the `check_file_upload_submission` function as it is no longer file upload specific.

I've also refactored way we retrieve the forms-runner URL and submission status URL to match what we do for the product pages and forms-admin.

I've tested this on dev by running this version of the end-to-end tests against dev with the `SES_SUBMISSIONS` feature flag disabled (which tests submission via Notify), and with it turned on (which tests submissions via SES).

### Things to consider when reviewing

- Ensure that you consider the wider context.
- Does it work when run on your machine?
- Is it clear what the code is doing?
- Do the commit messages explain why the changes were made?
- Has all relevant documentation been updated?
