### PR TITLE
Fix cuprite timeout syntax

### DIFF
--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -6,11 +6,11 @@ require_relative "support/feature_helpers"
 require_relative "support/logging"
 
 Capybara.register_driver(:cuprite) do |app|
-  Capybara::Cuprite::Driver.new(app, headless: false, browser_options: { "no-sandbox": nil }, options: { timeout: 20 })
+  Capybara::Cuprite::Driver.new(app, headless: false, timeout: 60, browser_options: { "no-sandbox": nil })
 end
 
 Capybara.register_driver(:cuprite_headless) do |app|
-  Capybara::Cuprite::Driver.new(app, headless: true, browser_options: { "no-sandbox": nil }, options: { timeout: 20 })
+  Capybara::Cuprite::Driver.new(app, headless: true, timeout: 60, browser_options: { "no-sandbox": nil })
 end
 
 Capybara.default_driver = ENV['GUI'] ? :cuprite : :cuprite_headless


### PR DESCRIPTION
### What problem does this pull request solve?

This PR fixes the syntax we used to set the cuprite timeout. It was still the 5 seconds default, but we didn't realise as the timeouts we see running the end-to-end tests are fluctuating around 5 seconds.