### PR TITLE
Schedule dependabot updates every Sunday

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -9,12 +9,14 @@ updates:
   - package-ecosystem: "github-actions"
     directory: "/"
     schedule:
-      interval: "daily"
+      interval: "weekly"
+      day: "sunday"
     open-pull-requests-limit: 10
 
   # Maintain dependencies for end to end tests using RSpec
   - package-ecosystem: "bundler"
     directory: "/"
     schedule:
-      interval: "daily"
+      interval: "weekly"
+      day: "sunday"
     open-pull-requests-limit: 10


### PR DESCRIPTION
### What problem does this pull request solve?

Dependabot updates are getting burdensome. Dependabot docs recommend [scheduling updates](https://docs.github.com/en/code-security/dependabot/dependabot-version-updates/optimizing-pr-creation-version-updates#controlling-the-frequency-and-timings-of-dependency-updates) to reduce this workload somewhat. The goal here is that the week's dependabot PRs would all be raised at the beginning of the working week, giving us time to sort them out before more get raised the following week. Security updates should still get raised along with associated security alerts.

In future we could also use groups to e.g. gather all dev dependencies into a single PR.

### Things to consider when reviewing

<!-- If this section isn't relevant for your PR feel free to edit or remove it -->

- Ensure that you consider the wider context.
- Does it work when run on your machine?
- Is it clear what the code is doing?
- Do the commit messages explain why the changes were made?
- Has all relevant documentation been updated?
