### PR TITLE
Remove branch feature flag conditional text

### DIFF
--- a/spec/support/feature_helpers.rb
+++ b/spec/support/feature_helpers.rb
@@ -223,13 +223,9 @@ module FeatureHelpers
     choose "1. #{selection_question}", visible: false
     click_button "Continue"
 
-    expect(page.find("h1")).to have_content /(Add a question route|Add route)/
-
-    if page.has_content? /is answered as/
-      select "Yes", from: "is answered as"
-    else
-      select "Yes", from: "If the answer selected is"
-    end
+    expect(page.find("h1")).to have_content "Add route"
+    
+    select "Yes", from: "If the answer selected is"
 
     select "Check your answers before submitting", from: "to"
     click_button "Save and continue"


### PR DESCRIPTION
To support the branch feature flag, we made the tests work for when the feature flag is enabled or disabled.

This was done by replacing text with regexes.

This commit replaces the conditional text with the current text values now that that feature flag has been removed and the branching feature released.

### What problem does this pull request solve?

Trello card: <!-- link -->

<!-- Add some description here about what the PR is about, even if you have a Trello card to link to -->

### Things to consider when reviewing

<!-- If this section isn't relevant for your PR feel free to edit or remove it -->

- Ensure that you consider the wider context.
- Does it work when run on your machine?
- Is it clear what the code is doing?
- Do the commit messages explain why the changes were made?
- Has all relevant documentation been updated?
