### PR TITLE
Fix create question method using wrong argument type

### DIFF
--- a/spec/support/feature_helpers.rb
+++ b/spec/support/feature_helpers.rb
@@ -54,9 +54,9 @@ module FeatureHelpers
 
     create_a_selection_question
 
-    create_a_single_line_of_text_question(question_text: question_text)
+    create_a_single_line_of_text_question(question_text)
 
-    create_a_single_line_of_text_question(question_text: alternate_question_text) # Adding a second question to test branching
+    create_a_single_line_of_text_question(alternate_question_text) # Adding a second question to test branching
 
     first(:link, "your questions").click
 
@@ -228,7 +228,7 @@ module FeatureHelpers
     click_button "Continue"
 
     expect(page.find("h1")).to have_content "Add route"
-    
+
     select "Yes", from: "If the answer selected is"
 
     select "3. #{alternate_question_text}", from: "to"


### PR DESCRIPTION
### What problem does this pull request solve?

Fixes the incorrect use of the `create_a_single_line_of_text_question` method, so that instead of passing in a key-value pair, it just passes in the string directly

<!-- Add some description here about what the PR is about, even if you have a Trello card to link to -->

### Things to consider when reviewing

<!-- If this section isn't relevant for your PR feel free to edit or remove it -->

- Ensure that you consider the wider context.
- Does it work when run on your machine?
- Is it clear what the code is doing?
- Do the commit messages explain why the changes were made?
- Has all relevant documentation been updated?
