### PR TITLE
Change privacy policy URL in created form tests

### DIFF
--- a/spec/support/feature_helpers.rb
+++ b/spec/support/feature_helpers.rb
@@ -110,7 +110,7 @@ module FeatureHelpers
     next_form_creation_step 'Provide a link to privacy information for this form'
 
     expect(page.find("h1")).to have_content 'Provide a link to privacy information for this form'
-    fill_in "Enter a link to privacy information for this form", with: "https://www.gov.uk/help/privacy-notice"
+    fill_in 'Enter a link to privacy information for this form', with: 'https://www.gov.uk/forms-made-up-example-privacy-notice'
     click_button "Save and continue"
 
     next_form_creation_step 'Provide contact details for support'


### PR DESCRIPTION
The privacy policy URL in form the tests create uses the example URL shown on the page.

The validation for the privacy policy URL has been changed to stop users entering the example URL.

This commit changes the privacy policy URL in the tests to a fictional URL which passes the validation.

### What problem does this pull request solve?

Trello card: <!-- link -->

<!-- Add some description here about what the PR is about, even if you have a Trello card to link to -->

### Things to consider when reviewing

<!-- If this section isn't relevant for your PR feel free to edit or remove it -->

- Ensure that you consider the wider context.
- Does it work when run on your machine?
- Is it clear what the code is doing?
- Do the commit messages explain why the changes were made?
- Has all relevant documentation been updated?
