### PR TITLE
Add Cuprite as an optional alternative to ChromeDriver

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -17,6 +17,7 @@ USER ruby
 
 COPY --chown=ruby:ruby . ./
 
+RUN bundle config set --local without cuprite
 RUN bundle install
 
 CMD ["bundle", "exec", "rspec"]

--- a/Gemfile
+++ b/Gemfile
@@ -5,6 +5,7 @@ ruby file: ".ruby-version"
 gem "debug"
 gem "rspec"
 gem "capybara"
+gem "cuprite", group: :cuprite
 gem "notifications-ruby-client"
 gem "selenium-webdriver"
 gem "webdrivers"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -31,12 +31,22 @@ GEM
       rack-test (>= 0.6.3)
       regexp_parser (>= 1.5, < 3.0)
       xpath (~> 3.2)
+    concurrent-ruby (1.3.5)
+    cuprite (0.17)
+      capybara (~> 3.0)
+      ferrum (~> 0.17.0)
     date (3.4.1)
     debug (1.11.0)
       irb (~> 1.10)
       reline (>= 0.3.8)
     diff-lcs (1.6.2)
     erb (5.0.1)
+    ferrum (0.17.1)
+      addressable (~> 2.5)
+      base64 (~> 0.2)
+      concurrent-ruby (~> 1.1)
+      webrick (~> 1.7)
+      websocket-driver (~> 0.7)
     io-console (0.8.0)
     irb (1.15.2)
       pp (>= 0.6.0)
@@ -108,7 +118,12 @@ GEM
       nokogiri (~> 1.6)
       rubyzip (>= 1.3.0)
       selenium-webdriver (~> 4.0)
+    webrick (1.9.1)
     websocket (1.2.11)
+    websocket-driver (0.8.0)
+      base64
+      websocket-extensions (>= 0.1.0)
+    websocket-extensions (0.1.5)
     xpath (3.2.0)
       nokogiri (~> 1.8)
 
@@ -123,6 +138,7 @@ PLATFORMS
 DEPENDENCIES
   aws-sdk-s3 (~> 1.192)
   capybara
+  cuprite
   debug
   notifications-ruby-client
   rake

--- a/README.md
+++ b/README.md
@@ -15,6 +15,9 @@ Make sure you have `chrome` and a matching version of `chromedriver` installed a
 
 You can follow [these instructions](https://chromedriver.chromium.org/getting-started) or download it directly from [chrome for testing](https://googlechromelabs.github.io/chrome-for-testing/).
 
+> [!TIP]
+> If you're having trouble with flaky tests, try using Cuprite instead of ChromeDriver with `USE_CUPRITE=1`
+
 Install the ruby dependencies:
 
 ```shell
@@ -40,6 +43,20 @@ You can run the tests against localhost using the following command:
 ```shell
 bundle exec rake
 ```
+
+### Choosing the browser automation protocol
+
+By default these tests use Selenium and ChromeDriver to talk to Chrome browser. However, since Chrome 134 users of Capybara with ChromeDriver have been reporting intermittent `Node with given id` and similar errors (see https://github.com/teamcapybara/capybara/issues/2800).
+
+As a potential workaround, you can use the [Cuprite] gem instead, by setting the environment variable `USE_CUPRITE`:
+
+```shell
+USE_CUPRITE=1 bundle exec rake
+```
+
+This is still an experimental change however, and needs more testing. In our automated pipelines we instead have pinned the version of Chrome used to a known good version.
+
+[Cuprite]: https://github.com/rubycdp/cuprite
 
 ### Skipping the product pages
 

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,47 +1,66 @@
 require 'capybara/rspec'
-require 'selenium/webdriver'
 require 'debug'
 
 require_relative "support/feature_helpers"
 require_relative "support/logging"
 
-options = Selenium::WebDriver::Chrome::Options.new
-options.add_preference(:download, prompt_for_download: false,
-                                  default_directory: '/tmp/downloads')
+if ENV['USE_CUPRITE']
+  begin
+    require 'capybara/cuprite'
 
-options.add_preference(:browser, set_download_behavior: { behavior: 'allow' })
+    Capybara.register_driver(:cuprite) do |app|
+      Capybara::Cuprite::Driver.new(app, headless: false, browser_options: { "no-sandbox": nil })
+    end
 
-Capybara.register_driver :chrome do |app|
-  Capybara::Selenium::Driver.new(app, browser: :chrome, options: options)
+    Capybara.register_driver(:cuprite_headless) do |app|
+      Capybara::Cuprite::Driver.new(app, headless: true, browser_options: { "no-sandbox": nil })
+    end
+
+    Capybara.default_driver = ENV['GUI'] ? :cuprite : :cuprite_headless
+  rescue LoadError
+    raise "Cannot use Cuprite as it does not appear to be installed; check your Bundler configuration"
+  end
+else
+  require 'selenium/webdriver'
+
+  options = Selenium::WebDriver::Chrome::Options.new
+  options.add_preference(:download, prompt_for_download: false,
+                                    default_directory: '/tmp/downloads')
+
+  options.add_preference(:browser, set_download_behavior: { behavior: 'allow' })
+
+  Capybara.register_driver :chrome do |app|
+    Capybara::Selenium::Driver.new(app, browser: :chrome, options: options)
+  end
+
+  Capybara.register_driver :headless_chrome do |app|
+    options.add_argument('--headless')
+    options.add_argument('--disable-gpu')
+    options.add_argument('--window-size=1280,1024')
+    options.add_argument('--no-sandbox')
+    options.add_argument('--disable-dev-shm-usage')
+
+    driver = Capybara::Selenium::Driver.new(app, browser: :chrome, options: options)
+
+    ### Allow file downloads in Google Chrome when headless!!!
+    ### https://bugs.chromium.org/p/chromium/issues/detail?id=696481#c89
+    bridge = driver.browser.send(:bridge)
+
+    path = '/session/:session_id/chromium/send_command'
+    path[':session_id'] = bridge.session_id
+
+    bridge.http.call(:post, path, cmd: 'Page.setDownloadBehavior',
+                                  params: {
+                                    behavior: 'allow',
+                                    downloadPath: '/tmp/downloads'
+                                  })
+    ###
+
+    driver
+  end
+
+  Capybara.default_driver = ENV['GUI'] ? :chrome : :headless_chrome
 end
-
-Capybara.register_driver :headless_chrome do |app|
-  options.add_argument('--headless')
-  options.add_argument('--disable-gpu')
-  options.add_argument('--window-size=1280,1024')
-  options.add_argument('--no-sandbox')
-  options.add_argument('--disable-dev-shm-usage')
-
-  driver = Capybara::Selenium::Driver.new(app, browser: :chrome, options: options)
-
-  ### Allow file downloads in Google Chrome when headless!!!
-  ### https://bugs.chromium.org/p/chromium/issues/detail?id=696481#c89
-  bridge = driver.browser.send(:bridge)
-
-  path = '/session/:session_id/chromium/send_command'
-  path[':session_id'] = bridge.session_id
-
-  bridge.http.call(:post, path, cmd: 'Page.setDownloadBehavior',
-                                params: {
-                                  behavior: 'allow',
-                                  downloadPath: '/tmp/downloads'
-                                })
-  ###
-
-  driver
-end
-
-Capybara.default_driver = ENV['GUI'] ? :chrome : :headless_chrome
 
 Capybara.configure do |config|
   config.automatic_label_click = true

--- a/spec/support/feature_helpers.rb
+++ b/spec/support/feature_helpers.rb
@@ -271,7 +271,7 @@ module FeatureHelpers
 
       expected_mail_reference = find_notification_reference("notification-id")
 
-      fill_in "What email address should completed forms be sent to?", with: test_email_address, fill_options: { clear: :backspace }
+      fill_in "What email address should completed forms be sent to?", with: test_email_address
       click_button "Save and continue"
 
       expect(page.find("h1")).to have_content 'Confirmation code sent'


### PR DESCRIPTION
### What problem does this pull request solve?

<!-- Add some description here about what the PR is about, even if you have a Trello card to link to -->

If USE_CUPRITE=1 then use [Cuprite] instead of ChromeDriver.

[Cuprite]: https://github.com/rubycdp/cuprite

Last time we tried Cuprite we tried to completely replace ChromeDriver (see PR #120), but that didn't work out too well (see PR #124)...

I've still found Cuprite to work well locally though, so this PR adds it back, but as an optional thing. This won't change the end to end tests in CodePipeline at all.

Maybe with more time to bed in it can work better this time around.

<!-- If this section isn't relevant for your PR feel free to edit or remove it -->

- Ensure that you consider the wider context.
- Does it work when run on your machine?
- Is it clear what the code is doing?
- Do the commit messages explain why the changes were made?
- Has all relevant documentation been updated?