### PR TITLE
Bump bundler from 2.6.3 to 2.7.1

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -152,4 +152,4 @@ RUBY VERSION
    ruby 3.4.1p0
 
 BUNDLED WITH
-   2.6.3
+   2.7.1


### PR DESCRIPTION
### What problem does this pull request solve?

<!-- Add some description here about what the PR is about, even if you have a Trello card to link to -->

Bumps [bundler](https://bundler.io/) from 2.6.3 to 2.7.1.

When using the latest version of RubyGems with Bundler 2.6.3 a number of
`redefined constant` errors are emitted, so this commit bumps Bundler.

- [Release notes](https://github.com/rubygems/rubygems/releases/tag/bundler-v2.7.1)
- [Changelog](https://github.com/rubygems/rubygems/blob/bundler-v2.7.1/bundler/CHANGELOG.md)
- [Commits](rubygems/rubygems@bundler-v2.6.3...bundler-v2.7.1)

Note that this bump drops support for Ruby 3.1.



### Things to consider when reviewing

<!-- If this section isn't relevant for your PR feel free to edit or remove it -->

- Ensure that you consider the wider context.
- Does it work when run on your machine?
- Is it clear what the code is doing?
- Do the commit messages explain why the changes were made?
- Has all relevant documentation been updated?