### PR TITLE
Bump lfdebrux/trello-poster-action from 1.1.0 to 1.2.0

### DIFF
--- a/.github/workflows/trello_poster.yml
+++ b/.github/workflows/trello_poster.yml
@@ -6,7 +6,7 @@ jobs:
   trello-poster:
     runs-on: ubuntu-latest
     steps:
-      - uses: lfdebrux/trello-poster-action@26a89a913f861d355dc2867a13c0c013e42d4c77
+      - uses: lfdebrux/trello-poster-action@736f8f21f0cacf6f4142d5c9e09ebd4439e83318 # v1.2.0
         with:
           comment-body: ${{ github.event.pull_request.body }}
           github-url: ${{ github.event.pull_request.html_url }}


### PR DESCRIPTION
### What problem does this pull request solve?

Trello card: https://trello.com/c/83jc9398/3029-github-trello-poster-is-broken-for-mirror-cards <!-- link -->

<!-- Add some description here about what the PR is about, even if you have a Trello card to link to -->

Bumps [lfdebrux/trello-poster-action](https://github.com/lfdebrux/trello-poster-action) from 1.1.0 to 1.2.0
- [Release notes](https://github.com/lfdebrux/trello-poster-action/pull/23)
- [Commits](https://github.com/lfdebrux/trello-poster-action/compare/v1.1.0...v1.2.0)


### Things to consider when reviewing

<!-- If this section isn't relevant for your PR feel free to edit or remove it -->

- Ensure that you consider the wider context.
- Does it work when run on your machine?
- Is it clear what the code is doing?
- Do the commit messages explain why the changes were made?
- Has all relevant documentation been updated?