### PR TITLE
Remove forms-api from setup guidance

### DIFF
--- a/README.md
+++ b/README.md
@@ -95,8 +95,6 @@ To run the tests:
   - start the server using an iam role that can assume the above role (eg: `gds aws forms-dev-readonly -- bundle exec rails s`)
 - in `forms-admin`
   - add your govuk_notify.api_key to settings.local.yml
-  - start the server (without aws)
-- in `forms-api`:
   - ensure the seeded s3 submission test form is set up correctly, and run the following rake task:
     - `rake "forms:set_submission_type_to_s3[2, ${the name of the submission bucket}, ${the aws account id where the bucket lives}, ${the region}]"`
   - start the server (without aws)


### PR DESCRIPTION
### What problem does this pull request solve?

Trello card: https://trello.com/c/BxY1aMOZ/2496-update-team-documentation-now-we-no-longer-use-forms-api <!-- link -->

<!-- Add some description here about what the PR is about, even if you have a Trello card to link to -->

forms-admin now serves form definitions and forms-api has been deprecated, update the documentation to reflect this.

### Things to consider when reviewing

<!-- If this section isn't relevant for your PR feel free to edit or remove it -->

- Ensure that you consider the wider context.
- Does it work when run on your machine?
- Is it clear what the code is doing?
- Do the commit messages explain why the changes were made?
- Has all relevant documentation been updated?