### PR TITLE
Bump bundler from 2.7.1 to 4.0.8

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -335,7 +335,7 @@ CHECKSUMS
   xpath (3.2.0) sha256=6dfda79d91bb3b949b947ecc5919f042ef2f399b904013eb3ef6d20dd3a4082e
 
 RUBY VERSION
-   ruby 3.4.4p34
+  ruby 3.4.4p34
 
 BUNDLED WITH
-   2.7.1
+  4.0.8


### PR DESCRIPTION
### What problem does this pull request solve?

<!-- Add some description here about what the PR is about, even if you have a Trello card to link to -->

Bumps [bundler](https://bundler.io) from 2.7.1 to 4.0.8.

- [Release notes](https://github.com/ruby/rubygems/releases/tag/bundler-v4.0.8)
- [Changelog](https://github.com/ruby/rubygems/blob/master/bundler/CHANGELOG.md)
- [Commits](https://github.com/ruby/rubygems/compare/bundler-v2.7.1...bundler-v4.0.8)


### Things to consider when reviewing

<!-- If this section isn't relevant for your PR feel free to edit or remove it -->

- Ensure that you consider the wider context.
- Does it work when run on your machine?
- Is it clear what the code is doing?
- Do the commit messages explain why the changes were made?
- Has all relevant documentation been updated?
