### PR TITLE
Assign cards to `TODO:` comments

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,5 @@
 # TODO: restore to latest version of Alpine once we can use the latest Chromium again (see https://github.com/teamcapybara/capybara/issues/2800)
+# https://trello.com/c/bFuui8d7/3458-unpin-alpine-version-in-forms-e2e-tests-once-chromedriver-issue-is-fixed
 ARG ALPINE_VERSION=3.20
 ARG RUBY_VERSION=3.4.4
 

--- a/spec/smoke_tests/smoke_test_runner_spec.rb
+++ b/spec/smoke_tests/smoke_test_runner_spec.rb
@@ -3,6 +3,7 @@
 feature "Runner Smoke Test", type: :feature do
   let(:smoke_test_form_url) do
     # TODO: Update this once we're confident no one is setting $SMOKE_TEST_FORM_URL
+    # https://trello.com/c/tIYmMZ3e/3457-remove-backwards-compatibility-for-legacy-e2e-test-env-vars
     if Settings.form_ids.smoke_test
       "#{Settings.forms_runner.url}/form/#{Settings.form_ids.smoke_test}"
     else

--- a/spec/support/aws_helpers.rb
+++ b/spec/support/aws_helpers.rb
@@ -48,6 +48,7 @@ module AwsHelpers
 
   def get_bucket
     # TODO: Update this once we're confident no one is setting $AWS_S3_BUCKET
+    # https://trello.com/c/tIYmMZ3e/3457-remove-backwards-compatibility-for-legacy-e2e-test-env-vars
     bucket = Settings.aws.file_upload_s3_bucket_name || ENV["AWS_S3_BUCKET"]
 
     raise "Settings.aws.file_upload_s3_bucket_name is not set" if bucket.nil? || bucket.empty?

--- a/spec/support/feature_helpers.rb
+++ b/spec/support/feature_helpers.rb
@@ -32,16 +32,19 @@ module FeatureHelpers
 
   def forms_admin_url
     # TODO: Update this once we're confident no one is setting $FORMS_ADMIN_URL
+    # https://trello.com/c/tIYmMZ3e/3457-remove-backwards-compatibility-for-legacy-e2e-test-env-vars
     Settings.forms_admin.url || ENV.fetch("FORMS_ADMIN_URL") { raise "Settings.forms_admin.url is not set" }
   end
 
   def forms_product_page_url
     # TODO: Update this once we're confident no one is setting $PRODUCT_PAGES_URL
+    # https://trello.com/c/tIYmMZ3e/3457-remove-backwards-compatibility-for-legacy-e2e-test-env-vars
     Settings.forms_product_page.url || ENV.fetch("PRODUCT_PAGES_URL") { raise "Settings.forms_product_page.url is not set" }
   end
 
   def forms_runner_url
     # TODO: Update this once we're confident no one is setting $FORMS_RUNNER_URL
+    # https://trello.com/c/tIYmMZ3e/3457-remove-backwards-compatibility-for-legacy-e2e-test-env-vars
     Settings.forms_runner.url || ENV.fetch("FORMS_RUNNER_URL") { raise "Settings.forms_runner.url is not set" }
   end
 
@@ -463,6 +466,7 @@ module FeatureHelpers
 
   def s3_form_is_filled_in_by_form_filler
     # TODO: Update this once we're confident no one is using $S3_FORM_ID
+    # https://trello.com/c/tIYmMZ3e/3457-remove-backwards-compatibility-for-legacy-e2e-test-env-vars
     form_id = Settings.form_ids.s3 || ENV.fetch("S3_FORM_ID") { raise "Settings.form_ids.s3 is not set" }
 
     s3_form_live_link = "#{forms_runner_url}/form/#{form_id}"
@@ -538,11 +542,13 @@ module FeatureHelpers
 
   def auth0_email_address
     # TODO: Update this once we're confident no one is setting $AUTH0_EMAIL_USERNAME
+    # https://trello.com/c/tIYmMZ3e/3457-remove-backwards-compatibility-for-legacy-e2e-test-env-vars
     Settings.forms_admin.auth.username || ENV.fetch("AUTH0_EMAIL_USERNAME") { raise "Settings.forms_admin.auth.username is not set" }
   end
 
   def auth0_password
     # TODO: Remove this once we're confident no one is setting $AUTH0_USER_PASSWORD
+    # https://trello.com/c/tIYmMZ3e/3457-remove-backwards-compatibility-for-legacy-e2e-test-env-vars
     Settings.forms_admin.auth.password || ENV.fetch("AUTH0_USER_PASSWORD") { raise "Settings.forms_admin.auth.password is not set" }
   end
 


### PR DESCRIPTION
### What problem does this pull request solve?
Trello card: https://trello.com/c/hK0527GN/219-review-todo-comments-and-make-product-cards-for-any-that-are-still-relevant

As part of firebreak work we've reviewed the outstanding TODO: comments in this repo and made tech debt cards for them.

This PR adds references to those tech debt cards in the codebase, so that anyone tackling the TODO tasks in future can easily check the card for additional context.

### Things to consider when reviewing

<!-- If this section isn't relevant for your PR feel free to edit or remove it -->

- Ensure that you consider the wider context.
- Does it work when run on your machine?
- Is it clear what the code is doing?
- Do the commit messages explain why the changes were made?
- Has all relevant documentation been updated?
