### PR TITLE
Update content for route option

### DIFF
--- a/spec/end_to_end/end_to_end_spec.rb
+++ b/spec/end_to_end/end_to_end_spec.rb
@@ -59,7 +59,7 @@ feature "Full lifecycle of a form", type: :feature do
       click_link "your questions", match: :first
 
       add_a_route selection_question, if_the_answer_selected_is: "Yes", skip_the_person_to: alternate_question_text
-      add_a_secondary_skip last_question_before_skip: question_text, question_to_skip_to: "Check your answers before submitting"
+      add_a_secondary_skip last_question_before_skip: question_text, question_to_skip_to: "End of form"
 
       finish_form_creation
 

--- a/spec/support/feature_helpers.rb
+++ b/spec/support/feature_helpers.rb
@@ -248,7 +248,13 @@ module FeatureHelpers
     expect(page.find("h1")).to have_content "Route for any other answer: set questions to skip"
 
     select last_question_before_skip, from: "Select the last question you want them to answer before they skip"
-    select question_to_skip_to, from: "Select the question to skip them to"
+
+    begin
+      select question_to_skip_to, from: "Select the question to skip them to"
+    rescue Capybara::ElementNotFound
+      # temporary fallback while we're deploying a change to this content
+      select "Check your answers before submitting", from: "Select the question to skip them to"
+    end
 
     click_button "Save and continue"
 


### PR DESCRIPTION
### What problem does this pull request solve?

Trello card: https://trello.com/c/LLGjGbXI

The option to skip to then end of the form for a route has been updated from "Check your answers before submitting" to "End of form".

Update the tests to use the new content with a temporary fallback to allow the tests to work with the new and old content temporarily

### Things to consider when reviewing

<!-- If this section isn't relevant for your PR feel free to edit or remove it -->

- Ensure that you consider the wider context.
- Does it work when run on your machine?
- Is it clear what the code is doing?
- Do the commit messages explain why the changes were made?
- Has all relevant documentation been updated?
