### PR TITLE
Remove temporary fallback for route option content

### DIFF
--- a/spec/support/feature_helpers.rb
+++ b/spec/support/feature_helpers.rb
@@ -248,13 +248,7 @@ module FeatureHelpers
     expect(page.find("h1")).to have_content "Route for any other answer: set questions to skip"
 
     select last_question_before_skip, from: "Select the last question you want them to answer before they skip"
-
-    begin
-      select question_to_skip_to, from: "Select the question to skip them to"
-    rescue Capybara::ElementNotFound
-      # temporary fallback while we're deploying a change to this content
-      select "Check your answers before submitting", from: "Select the question to skip them to"
-    end
+    select question_to_skip_to, from: "Select the question to skip them to"
 
     click_button "Save and continue"
 


### PR DESCRIPTION
### What problem does this pull request solve?

Trello card: https://trello.com/c/LLGjGbXI

The content change has now been deployed, so the fallback to use the old content is no longer needed.

### Things to consider when reviewing

<!-- If this section isn't relevant for your PR feel free to edit or remove it -->

- Ensure that you consider the wider context.
- Does it work when run on your machine?
- Is it clear what the code is doing?
- Do the commit messages explain why the changes were made?
- Has all relevant documentation been updated?
