### PR TITLE
Update the content for the end of form routing option

### DIFF
--- a/spec/end_to_end/end_to_end_spec.rb
+++ b/spec/end_to_end/end_to_end_spec.rb
@@ -59,7 +59,7 @@ feature "Full lifecycle of a form", type: :feature do
       click_link "your questions", match: :first
 
       add_a_route selection_question, if_the_answer_selected_is: "Yes", skip_the_person_to: alternate_question_text
-      add_a_secondary_skip last_question_before_skip: question_text, question_to_skip_to: "End of form"
+      add_a_secondary_skip last_question_before_skip: question_text, question_to_skip_to: "End of the form"
 
       finish_form_creation
 

--- a/spec/support/feature_helpers.rb
+++ b/spec/support/feature_helpers.rb
@@ -248,7 +248,12 @@ module FeatureHelpers
     expect(page.find("h1")).to have_content "Route for any other answer: set questions to skip"
 
     select last_question_before_skip, from: "Select the last question you want them to answer before they skip"
-    select question_to_skip_to, from: "Select the question to skip them to"
+    begin
+      select question_to_skip_to, from: "Select the question to skip them to"
+    rescue Capybara::ElementNotFound
+      # temporary fallback while we're deploying a change to this content
+      select "End of form", from: "Select the question to skip them to"
+    end
 
     click_button "Save and continue"
 


### PR DESCRIPTION
https://github.com/govuk-forms/forms-admin/pull/2777 updated the option from "End of form" to "End of the form".

Update the e2e tests and add in a temporary fallback to allow the tests to pass with the old content to allow the change to be rolled out.