### PR TITLE
Update form details link

### DIFF
--- a/spec/support/feature_helpers.rb
+++ b/spec/support/feature_helpers.rb
@@ -95,7 +95,7 @@ module FeatureHelpers
     click_button "Save and continue"
     expect(page.find("h1")).to have_content "Your form is live"
 
-    click_link "Continue to form details"
+    click_link "Continue to the live form’s details"
 
     expect(page.find("h1")).to have_content form_name
   end


### PR DESCRIPTION
We previously updated this link text in forms-admin, which broke the tests.

### What problem does this pull request solve?

Trello card: <!-- link -->https://trello.com/c/VUw58sEk/2891-add-confirmation-pages-for-english-welsh-when-a-form-version-has-been-made-live

<!-- Add some description here about what the PR is about, even if you have a Trello card to link to -->
Updates some link text to match a change in admin which broke the tests.

### Things to consider when reviewing

<!-- If this section isn't relevant for your PR feel free to edit or remove it -->

- Ensure that you consider the wider context.
- Does it work when run on your machine?
- Is it clear what the code is doing?
- Do the commit messages explain why the changes were made?
- Has all relevant documentation been updated?
