### PR TITLE
Fix flaky test

### DIFF
--- a/spec/support/aws_helpers.rb
+++ b/spec/support/aws_helpers.rb
@@ -65,6 +65,8 @@ module AwsHelpers
     objects.contents.each do |object|
       return object.key if object.key.include? reference_number
     end
+
+    nil
   end
 
   def delete_file_from_s3(client, bucket, key)


### PR DESCRIPTION
### What problem does this pull request solve?

<!-- Add some description here about what the PR is about, even if you have a Trello card to link to -->

Callers of find_key were assuming that it would return a falsey object if the S3 object did not exist, but it was returning an Aws::Xml::DefaultList instead. This was causing the end to end tests to fail in the pipeline intermittently. This commit hopefully fixes the issue.


### Things to consider when reviewing

<!-- If this section isn't relevant for your PR feel free to edit or remove it -->

- Ensure that you consider the wider context.
- Does it work when run on your machine?
- Is it clear what the code is doing?
- Do the commit messages explain why the changes were made?
- Has all relevant documentation been updated?
