### PR TITLE
Add test for copy of answers feature

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -7,6 +7,7 @@ gem "capybara"
 gem "config"
 gem "debug"
 gem "notifications-ruby-client"
+gem "rotp"
 gem "rspec"
 gem "selenium-webdriver"
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -138,6 +138,7 @@ GEM
     reline (0.6.3)
       io-console (~> 0.5)
     rexml (3.4.4)
+    rotp (6.3.0)
     rspec (3.13.2)
       rspec-core (~> 3.13.0)
       rspec-expectations (~> 3.13.0)
@@ -237,6 +238,7 @@ DEPENDENCIES
   notifications-ruby-client
   openssl
   rake
+  rotp
   rspec
   rubocop-govuk
   selenium-webdriver
@@ -253,7 +255,6 @@ CHECKSUMS
   aws-sigv4 (1.12.1) sha256=6973ff95cb0fd0dc58ba26e90e9510a2219525d07620c8babeb70ef831826c00
   base64 (0.3.0) sha256=27337aeabad6ffae05c265c450490628ef3ebd4b67be58257393227588f5a97b
   bigdecimal (4.1.2) sha256=53d217666027eab4280346fba98e7d5b66baaae1b9c3c1c0ffe89d48188a3fbd
-  bundler (4.0.12) sha256=7f8b757d28dfb636e7b24fba2344ac6dd13b5b24f4b46d62573d483f211825ac
   capybara (3.40.0) sha256=42dba720578ea1ca65fd7a41d163dd368502c191804558f6e0f71b391054aeef
   concurrent-ruby (1.3.6) sha256=6b56837e1e7e5292f9864f34b69c5a2cbc75c0cf5338f1ce9903d10fa762d5ab
   config (5.6.1) sha256=a9f0f0f9ffa6d12d43147a3fa1ab8486fe484c3098a350c6a2e0f32430e0d1cc
@@ -307,6 +308,7 @@ CHECKSUMS
   regexp_parser (2.12.0) sha256=35a916a1d63190ab5c9009457136ae5f3c0c7512d60291d0d1378ba18ce08ebb
   reline (0.6.3) sha256=1198b04973565b36ec0f11542ab3f5cfeeec34823f4e54cebde90968092b1835
   rexml (3.4.4) sha256=19e0a2c3425dfbf2d4fc1189747bdb2f849b6c5e74180401b15734bc97b5d142
+  rotp (6.3.0) sha256=75d40087e65ed0d8022c33055a6306c1c400d1c12261932533b5d6cbcd868854
   rspec (3.13.2) sha256=206284a08ad798e61f86d7ca3e376718d52c0bc944626b2349266f239f820587
   rspec-core (3.13.6) sha256=a8823c6411667b60a8bca135364351dda34cd55e44ff94c4be4633b37d828b2d
   rspec-expectations (3.13.5) sha256=33a4d3a1d95060aea4c94e9f237030a8f9eae5615e9bd85718fe3a09e4b58836

--- a/README.md
+++ b/README.md
@@ -71,6 +71,10 @@ The end to end tests can be run without testing a form with the `submission_type
 
 The end to end tests can be run without testing a form with a file upload question by setting the `SKIP_FILE_UPLOAD` environment variable to `1`.
 
+### Skipping receiving a copy of answers using GOV.UK One Login
+
+The end to end tests can be run without testing receiving a copy of answers using GOV.UK One Login by setting the `SKIP_COPY_OF_ANSWERS` environment variable to `1`.
+
 ### Running the file upload test
 
 Forms-runner needs to be started with the AWS credentials for the dev account for the file upload test to pass, as follows:

--- a/README.md
+++ b/README.md
@@ -24,24 +24,37 @@ Install the ruby dependencies:
 bundle install
 ```
 
-#### GOV.UK Notify API keys
-
-Set in your environment:
-
-```shell
-export SETTINGS__GOVUK_NOTIFY__API_KEY=<your api key>
-```
-
-Ensure both the forms-admin and forms-runner services are also configured to use the Notify API - see their respective READMEs for details.
-
 ### Running the tests locally
 
 The tests expect an active group to exist called "End to end tests", which the test user belongs as a group admin. This name can be overridden by setting the environment variable `SETTINGS__END_TO_END_TESTS__GROUP_NAME`.
 
+#### Starting forms-runner
+
+Forms-runner needs to be started with:
+- The Notify API key in order to send confirmation emails
+- AWS credentials for the dev account in order to send submissions
+
+```shell
+gds aws forms-dev-readonly --shell
+
+ASSUME_DEV_IAM_ROLE=true SETTINGS__GOVUK_NOTIFY__API_KEY=<notify-api-key> ./bin/rails server
+```
+
+see the [README for forms-runner](https://github.com/govuk-forms/forms-runner?tab=readme-ov-file#getting-aws-credentials) for more details
+
+#### Starting forms-admin
+
+Forms-admin needs to be started with the Notify API key to send the submission email verification code:
+```
+SETTINGS__GOVUK_NOTIFY__API_KEY=<notify-api-key> ./bin/rails server
+```
+
+#### Running the tests
+
 You can run the tests against localhost using the following command:
 
 ```shell
-bundle exec rake
+SETTINGS__GOVUK_NOTIFY__API_KEY=<your api key> bundle exec rake
 ```
 
 ### Choosing the browser automation protocol
@@ -75,46 +88,16 @@ The end to end tests can be run without testing a form with a file upload questi
 
 The end to end tests can be run without testing receiving a copy of answers using GOV.UK One Login by setting the `SKIP_COPY_OF_ANSWERS` environment variable to `1`.
 
-### Running the file upload test
-
-Forms-runner needs to be started with the AWS credentials for the dev account for the file upload test to pass, as follows:
-
-- `gds aws forms-dev-readonly --shell`
-- `ASSUME_DEV_IAM_ROLE=true SETTINGS__GOVUK_NOTIFY__API_KEY='<notify-api-key>' ./bin/rails server`
-- see the [README for forms-runner](https://github.com/govuk-forms/forms-runner?tab=readme-ov-file#getting-aws-credentials) for more details
-
 ### Running the s3 submission test
 
-You will need:
+The S3 submission tests use a form created by the forms-admin seed data locally. On remote environments, it uses forms configured manually by us, with the form ID passed in using the `SETTINGS__FORM_IDS__S3` environment variable.
 
-- an aws iam role.
-  - This is the role with permissions to upload to and delete from an s3 bucket, and that you have permission to assume. When running the tests locally, this will be the [s3 end to end test role](https://github.com/govuk-forms/forms-deploy/blob/2a8720380219ac854d3c1d008e6b82af67e4a7b2/infra/modules/forms-runner/s3-end-to-end-test-role.tf#L2) in the dev environment,
-- an s3 bucket.
-  - This bucket should be set up so that the above role can access it. When running the tests locally, this will be [the submissions test bucket](https://github.com/govuk-forms/forms-deploy/blob/2a8720380219ac854d3c1d008e6b82af67e4a7b2/infra/deployments/deploy/tools/submissions-to-s3-test-bucket.tf#L4) created in the deploy account.
-
-To run the tests:
-
-- in `forms-runner`:
-  - add your govuk_notify.api_key and aws.s3_submission_iam_role to settings.local.yml
-  - start the server using an iam role that can assume the above role (eg: `gds aws forms-dev-readonly -- bundle exec rails s`)
-- in `forms-admin`
-  - add your govuk_notify.api_key to settings.local.yml
-  - ensure the seeded s3 submission test form is set up correctly, and run the following rake task:
-    - `rake "forms:submission_type:set_to_s3[2, ${the name of the submission bucket}, ${the aws account id where the bucket lives}, ${the region}, csv]"`
-  - start the server (without aws)
-- in `forms-e2e-tests`
-  - start an aws shell:
-    - `gds aws forms-dev-readonly --shell`
-  - run the end to end tests tests:
+The S3 tests need to assume an IAM role to access the submissions S3 bucket. Run the e2e tests in an AWS shell so we can assume this role:
 
 ```shell
-SETTINGS__AWS__FILE_UPLOAD_S3_BUCKET_NAME=${ the name of the s3 bucket }\
-SETTINGS__AWS__S3_SUBMISSION_IAM_ROLE_ARN=${ the iam role arn } \
-SETTINGS__GOVUK_NOTIFY__API_KEY=${ your notify api key here } \
-SKIP_AUTH=1 \
-SKIP_PRODUCT_PAGES=1 \
-LOG_LEVEL=info \
-bundle exec rspec spec/end_to_end
+gds aws forms-dev-readonly --shell
+
+SKIP_S3=0 bundle exec rake
 ```
 
 ### Running the tests against remote environments

--- a/README.md
+++ b/README.md
@@ -100,9 +100,26 @@ gds aws forms-dev-readonly --shell
 SKIP_S3=0 bundle exec rake
 ```
 
+### Running the test to get a copy of answers using GOV.UK One Login
+
+forms-runner needs to be started with the One Login client details. See the [README for forms-runner](https://github.com/govuk-forms/forms-runner#configuring-govuk-one-login) to configure these.
+
+We need to run tests with the One Login sign in details for the test user by setting the `SETTINGS__GOVUK_ONE_LOGIN__USER_PASSWORD` and `SETTINGS__GOVUK_ONE_LOGIN__USER_OTP_SECRET_KEY` environment variables. Obtain the values for these from the [AWS parameter store](https://github.com/govuk-forms/forms-deploy/blob/c586c1368dd9acbe79a819aa4c32a5ef3229d686/infra/modules/automated-test-parameters/parameters.tf#L49) on the dev environment. 
+
+The tests need to assume an IAM role to check the email with a copy of the answers is delivered to an S3 bucket. Run the e2e tests in an AWS shell so we can assume this role:
+
+```shell
+gds aws forms-dev-readonly --shell
+
+SKIP_COPY_OF_ANSWERS=0 \
+SETTINGS__GOVUK_ONE_LOGIN__USER_PASSWORD=<password> \
+SETTINGS__GOVUK_ONE_LOGIN__USER_OTP_SECRET_KEY=<secret key> \
+bundle exec rake
+```
+
 ### Running the tests against remote environments
 
-To run the tests against one of the standard environemnts you can use the end_to_end.sh script.
+To run the tests against one of the standard environments you can use the end_to_end.sh script.
 
 Run it in an authenticated shell with permission to access SSM params in forms-deploy using the gds-cli or aws-vault
 

--- a/Rakefile
+++ b/Rakefile
@@ -10,6 +10,7 @@ RSpec::Core::RakeTask.new(:end_to_end) do |task|
   ENV["SKIP_AUTH"] ||= "1"
   ENV["SKIP_S3"] ||= "1"
   ENV["SKIP_FILE_UPLOAD"] ||= "1"
+  ENV["SKIP_COPY_OF_ANSWERS"] ||= "1"
 
   task.pattern = %(spec/end_to_end)
   task.verbose = false

--- a/config/settings.yml
+++ b/config/settings.yml
@@ -22,9 +22,15 @@ forms_runner:
 aws:
   file_upload_s3_bucket_name:
   s3_submission_iam_role_arn:
+  email_receiver_s3_bucket_name:
 
 govuk_notify:
   api_key:
+
+govuk_one_login:
+  user_email:
+  user_password:
+  user_otp_secret_key:
 
 submission_status_api:
   secret:

--- a/config/settings.yml
+++ b/config/settings.yml
@@ -20,7 +20,7 @@ forms_runner:
   url:
 
 aws:
-  file_upload_s3_bucket_name:
+  file_upload_s3_bucket_name: # This name is wrong, this should be the bucket for submissions so S3
   s3_submission_iam_role_arn:
   email_receiver_s3_bucket_name:
 

--- a/config/settings/development.yml
+++ b/config/settings/development.yml
@@ -15,3 +15,6 @@ forms_product_page:
 
 submission_status_api:
   secret: test_token
+
+govuk_one_login:
+  user_email: copy-of-answers-emails-tests@dev.forms.service.gov.uk

--- a/config/settings/development.yml
+++ b/config/settings/development.yml
@@ -16,5 +16,10 @@ forms_product_page:
 submission_status_api:
   secret: test_token
 
+aws:
+  file_upload_s3_bucket_name: govuk-forms-submissions-to-s3-test
+  s3_submission_iam_role_arn: arn:aws:iam::498160065950:role/govuk-s3-end-to-end-test-dev
+  email_receiver_s3_bucket_name: govuk-forms-dev-test-emails
+
 govuk_one_login:
   user_email: copy-of-answers-emails-tests@dev.forms.service.gov.uk

--- a/spec/end_to_end/end_to_end_spec.rb
+++ b/spec/end_to_end/end_to_end_spec.rb
@@ -81,6 +81,11 @@ feature "Full lifecycle of a form", type: :feature do
         logger.info
         logger.info "Scenario: Form is completed by a member of the public, and they request a confirmation email"
         form_is_filled_in_by_form_filler(live_form_link, confirmation_email: test_email_address)
+
+        unless skip_copy_of_answers?
+          logger.info "Scenario: Form is completed by a member of the public, and they request a copy of their answers"
+          form_is_filled_in_by_form_filler(live_form_link, copy_of_answers: true)
+        end
       end
 
       visit_admin

--- a/spec/end_to_end/end_to_end_spec.rb
+++ b/spec/end_to_end/end_to_end_spec.rb
@@ -89,7 +89,7 @@ feature "Full lifecycle of a form", type: :feature do
     end
   end
 
-  unless ENV.fetch("SKIP_S3", false)
+  unless %w[1 true t yes y].include? ENV.fetch("SKIP_S3", false).to_s.strip.downcase
     # Testing s3 submission
     scenario "Form is completed by a member of the public, and answers are sent to s3" do
       logger.info

--- a/spec/support/aws_helpers.rb
+++ b/spec/support/aws_helpers.rb
@@ -3,34 +3,85 @@
 require "aws-sdk-s3"
 
 module AwsHelpers
-  S3_SUBMISSION_LOOKUP_TIMEOUT_SECONDS = 60
+  LOOKUP_TIMEOUT_SECONDS = 60
 
-  def get_file_from_s3(reference_number, form_id)
-    credentials = assume_role
-    client = Aws::S3::Client.new(
-      region: "eu-west-2",
-      credentials: credentials,
-    )
-
-    bucket = get_bucket
+  def get_file_from_s3(submission_reference, form_id)
+    bucket = get_submissions_bucket
     started_at = Time.now
+    attempts = 0
 
     loop do
-      key = find_key(client, reference_number, bucket, form_id)
+      key = find_key(submission_reference, bucket, form_id)
 
       if key
-        csv = client.get_object(bucket: bucket, key: key)
-        delete_file_from_s3(client, bucket, key)
+        csv = s3_client.get_object(bucket: bucket, key: key)
+        delete_from_s3(bucket, key)
         return csv.body.read
       end
 
       elapsed_seconds = Time.now - started_at
-      if elapsed_seconds >= S3_SUBMISSION_LOOKUP_TIMEOUT_SECONDS
-        raise "Could not find S3 submission file for reference #{reference_number} after #{attempts} attempts in #{S3_SUBMISSION_LOOKUP_TIMEOUT_SECONDS}s"
+      attempts += 1
+      if elapsed_seconds >= LOOKUP_TIMEOUT_SECONDS
+        raise "Could not find S3 submission file for reference #{submission_reference} after #{attempts} attempts in #{LOOKUP_TIMEOUT_SECONDS}s"
       end
 
       sleep 1
     end
+  end
+
+  def wait_for_copy_of_answers_email(submission_reference)
+    prefix = "copy-of-answers-emails/"
+    email_match_string = "Your form reference number is #{submission_reference}"
+    wait_for_ses_email_delivered_to_s3(prefix, email_match_string, submission_reference)
+  end
+
+  def wait_for_ses_email_delivered_to_s3(prefix, email_match_string, submission_reference)
+    bucket = Settings.aws.email_receiver_s3_bucket_name
+    started_at = Time.now
+    attempts = 0
+
+    check_objects_modified_after = Time.now - 30 # 30 seconds ago
+    checked_keys = Set.new
+
+    loop do
+      # list_objects_v2 returns a maximum of 1000 keys per request, use the enumerator to handle pagination
+      s3_client.list_objects_v2(bucket: bucket, prefix: prefix).each do |response|
+        response.contents.each do |object_metadata|
+          key = object_metadata.key
+          next if object_metadata.last_modified < check_objects_modified_after
+          next if checked_keys.include?(key)
+
+          object = s3_client.get_object(bucket: bucket, key: key)
+          body = object.body.read
+          if body.include?(email_match_string)
+            delete_from_s3(bucket, key)
+            return body
+          end
+
+          checked_keys.add(key)
+        end
+      end
+
+      elapsed_seconds = Time.now - started_at
+      attempts += 1
+      if elapsed_seconds >= LOOKUP_TIMEOUT_SECONDS
+        raise "Could not find email in #{bucket} S3 bucket with key prefix #{prefix} for submission #{submission_reference} after #{attempts} attempts in #{LOOKUP_TIMEOUT_SECONDS}s"
+      end
+
+      sleep 1
+    end
+  end
+
+private
+
+  def s3_client
+    return @s3_client if @s3_client
+
+    credentials = assume_role
+    @s3_client = Aws::S3::Client.new(
+      region: "eu-west-2",
+      credentials: credentials,
+    )
   end
 
   def assume_role
@@ -46,7 +97,7 @@ module AwsHelpers
     )
   end
 
-  def get_bucket
+  def get_submissions_bucket
     # TODO: Update this once we're confident no one is setting $AWS_S3_BUCKET
     # https://trello.com/c/tIYmMZ3e/3457-remove-backwards-compatibility-for-legacy-e2e-test-env-vars
     bucket = Settings.aws.file_upload_s3_bucket_name || ENV["AWS_S3_BUCKET"]
@@ -56,21 +107,21 @@ module AwsHelpers
     bucket
   end
 
-  def find_key(client, reference_number, bucket, form_id)
-    objects = client.list_objects({
+  def find_key(submission_reference, bucket, form_id)
+    objects = s3_client.list_objects({
       bucket: bucket,
       prefix: "form_submissions/#{form_id}/",
     })
 
     objects.contents.each do |object|
-      return object.key if object.key.include? reference_number
+      return object.key if object.key.include? submission_reference
     end
 
     nil
   end
 
-  def delete_file_from_s3(client, bucket, key)
-    client.delete_object({
+  def delete_from_s3(bucket, key)
+    s3_client.delete_object({
       bucket: bucket,
       key: key,
     })

--- a/spec/support/aws_helpers.rb
+++ b/spec/support/aws_helpers.rb
@@ -108,13 +108,11 @@ private
   end
 
   def find_key(submission_reference, bucket, form_id)
-    objects = s3_client.list_objects({
-      bucket: bucket,
-      prefix: "form_submissions/#{form_id}/",
-    })
-
-    objects.contents.each do |object|
-      return object.key if object.key.include? submission_reference
+    # list_objects_v2 returns a maximum of 1000 keys per request, use the enumerator to handle pagination
+    s3_client.list_objects_v2(bucket: bucket, prefix: "form_submissions/#{form_id}/").each do |response|
+      response.contents.each do |object|
+        return object.key if object.key.include? submission_reference
+      end
     end
 
     nil

--- a/spec/support/feature_helpers.rb
+++ b/spec/support/feature_helpers.rb
@@ -1,5 +1,6 @@
 # frozen_string_literal: true
 
+require "rotp"
 require_relative "./notify_helpers"
 require_relative "./aws_helpers"
 
@@ -79,6 +80,8 @@ module FeatureHelpers
     check "Email", visible: false
     fill_in "Enter the email address", with: test_email_address
     click_button "Save and continue"
+
+    enable_copy_of_answers
 
     next_form_creation_step "Share a preview of your draft form"
 
@@ -297,6 +300,15 @@ module FeatureHelpers
     click_link "Continue creating a form"
   end
 
+  def enable_copy_of_answers
+    next_form_creation_step "Give people the option to ask for a copy of their answers"
+
+    expect(page.find("h1")).to have_content "Give people the option to get a copy of their answers by email"
+
+    check "Give people the option to get a copy of their answers by email - I’m ok with the risk", visible: false
+    click_button "Save and continue"
+  end
+
   def delete_form(form_name)
     if page.has_link?(form_name)
       click_link(form_name, match: :one, exact: true)
@@ -315,7 +327,7 @@ module FeatureHelpers
     end
   end
 
-  def form_is_filled_in_by_form_filler(live_form_link, yes_branch: false, confirmation_email: nil)
+  def form_is_filled_in_by_form_filler(live_form_link, yes_branch: false, confirmation_email: nil, copy_of_answers: false)
     logger.info
     logger.info "As a form filler"
 
@@ -362,9 +374,31 @@ module FeatureHelpers
     end
     # rubocop:enable Style/IdenticalConditionalBranches
 
-    if page.find("h1").has_content?("Do you want to get an email with a copy of your answers?")
-      logger.info "And I am asked if I want a copy of my answers"
-      expect(page.find("h1")).to have_content "Do you want to get an email with a copy of your answers?"
+    logger.info "And I am asked if I want a copy of my answers"
+    expect(page.find("h1")).to have_content "Do you want to get an email with a copy of your answers?"
+
+    if copy_of_answers
+      logger.info "And I choose 'Yes'"
+      choose "Yes", visible: false
+      click_button "Continue"
+
+      expect(page.find("h1")).to have_content "Use GOV.UK One Login to keep your information secure"
+      click_button "Continue to GOV.UK One Login"
+
+      logger.info "Then I log in using GOV.UK One Login"
+      expect(page.current_url).to start_with("https://signin.integration.account.gov.uk/")
+      click_button "Sign in"
+
+      find('input[type="email"]', visible: true).set(Settings.govuk_one_login.user_email)
+      find('button[type="submit"]').click
+
+      find('input[type="password"]', visible: true).set(Settings.govuk_one_login.user_password)
+      find('button[type="submit"]').click
+
+      find('input[autocomplete="one-time-code"]', visible: true).set(generate_one_login_otp)
+      find('button[type="submit"]').click
+    else
+      logger.info "And I choose 'No'"
       choose "No", visible: false
       click_button "Continue"
     end
@@ -646,6 +680,11 @@ module FeatureHelpers
   def click_group(group_name)
     click_link group_name
     expect(page.find("h1")).to have_content group_name
+  end
+
+  def generate_one_login_otp
+    totp = ROTP::TOTP.new(Settings.govuk_one_login.user_otp_secret_key)
+    totp.now
   end
 end
 

--- a/spec/support/feature_helpers.rb
+++ b/spec/support/feature_helpers.rb
@@ -441,7 +441,9 @@ module FeatureHelpers
     logger.info "When a form filler has submitted their answers"
     logger.info "Then I can see their submission in my email inbox"
 
-    check_submission
+    submission_reference = page.find("#submission-reference").text
+
+    check_submission(submission_reference)
 
     if confirmation_email_reference
       logger.info
@@ -450,6 +452,10 @@ module FeatureHelpers
       logger.info "Then I can see the confirmation in my email inbox"
 
       wait_for_notification(confirmation_email_reference)
+    end
+
+    if copy_of_answers
+      wait_for_copy_of_answers_email(submission_reference)
     end
   end
 
@@ -468,9 +474,7 @@ module FeatureHelpers
     expect(page).to have_content "Your form has been submitted"
   end
 
-  def check_submission
-    submission_reference = page.find("#submission-reference").text
-
+  def check_submission(submission_reference)
     uri = URI(submission_status_url)
     uri.query = URI.encode_www_form(reference: submission_reference)
 

--- a/spec/support/feature_helpers.rb
+++ b/spec/support/feature_helpers.rb
@@ -593,6 +593,10 @@ module FeatureHelpers
     ENV.fetch("SKIP_FILE_UPLOAD", false)
   end
 
+  def skip_copy_of_answers?
+    ENV.fetch("SKIP_COPY_OF_ANSWERS", false)
+  end
+
   def visit_product_page
     logger.info "Visiting product pages at #{forms_product_page_url}"
     visit forms_product_page_url

--- a/spec/support/feature_helpers.rb
+++ b/spec/support/feature_helpers.rb
@@ -534,7 +534,7 @@ module FeatureHelpers
   end
 
   def sign_in
-    return if ENV.fetch("SKIP_AUTH", false)
+    return if skip_auth?
 
     sign_in_to_auth0
     logger.debug "Sign in successful"
@@ -586,15 +586,31 @@ module FeatureHelpers
   end
 
   def skip_product_pages?
-    ENV.fetch("SKIP_PRODUCT_PAGES", false)
+    evaluate_boolean_env_var("SKIP_PRODUCT_PAGES")
   end
 
   def skip_file_upload?
-    ENV.fetch("SKIP_FILE_UPLOAD", false)
+    evaluate_boolean_env_var("SKIP_FILE_UPLOAD")
   end
 
   def skip_copy_of_answers?
-    ENV.fetch("SKIP_COPY_OF_ANSWERS", false)
+    evaluate_boolean_env_var("SKIP_COPY_OF_ANSWERS")
+  end
+
+  def skip_s3?
+    evaluate_boolean_env_var("SKIP_S3")
+  end
+
+  def skip_auth?
+    evaluate_boolean_env_var("SKIP_AUTH")
+  end
+
+  def evaluate_boolean_env_var(var_name, default: false)
+    value = ENV.fetch(var_name, default)
+    return false if value.nil?
+    return true if %w[1 true t yes y].include? value.to_s.strip.downcase
+
+    false
   end
 
   def visit_product_page


### PR DESCRIPTION
### What problem does this pull request solve?

Trello card: https://trello.com/c/lnW6zOUs

This adds a step to the forms-admin form setup to enable getting a copy of the answers for a form.

It adds a separate user journey to fill out the form and log into GOV.UK One Login to receive a copy of the answers, which can be skipped locally using an environment variable.

We have an SES receiver rule set up to send emails that are addressed to a test email address to an S3 bucket. The tests log into GOV.UK One Login with an account linked to this email address. The login details for the One Login account per environment are passed in as environment variables.

The test checks for the presence of the copy of answers confirmation email in an S3 bucket by polling the bucket for recent keys with the prefix "copy-of-answers-emails/" and checking the contents of the email for a string containing the submission reference.

### Things to consider when reviewing

<!-- If this section isn't relevant for your PR feel free to edit or remove it -->

- Ensure that you consider the wider context.
- Does it work when run on your machine?
- Is it clear what the code is doing?
- Do the commit messages explain why the changes were made?
- Has all relevant documentation been updated?
