### PR TITLE
Update script to run against environments for copy of answers test

### DIFF
--- a/README.md
+++ b/README.md
@@ -121,12 +121,12 @@ bundle exec rake
 
 To run the tests against one of the standard environments you can use the end_to_end.sh script.
 
-Run it in an authenticated shell with permission to access SSM params in forms-deploy using the gds-cli or aws-vault
+Run it in an authenticated shell with permission to access SSM params in the desired environment.
 
 For example, to run the tests against the development environment, use:
 
 ```bash
-gds aws forms-deploy-readonly bin/end_to_end.sh dev
+gds aws forms-dev-readonly -- bin/end_to_end.sh dev
 ```
 
 Change `dev` to `staging` or `production` to run the tests against those environments.

--- a/bin/end_to_end.sh
+++ b/bin/end_to_end.sh
@@ -11,12 +11,12 @@ if [[ -z "$environment" ]] || [[ "$1" == "help" ]] || [[ -z "$AWS_ACCESS_KEY_ID"
   echo "Runs the Capybara end-to-end tests for the given environment.
 
 Run in an authenticated shell with permission to access ssm params in
-forms-deploy using the gds-cli or aws-vault
+the desired environment
 
 Usage: $0 dev|staging|production
 
 Example:
-gds aws forms-deploy-readonly -- $0 dev
+gds aws forms-dev-readonly -- $0 dev
 "
   exit 0
 fi

--- a/bin/load_env_vars.sh
+++ b/bin/load_env_vars.sh
@@ -71,6 +71,18 @@ function aws_s3_bucket() {
   esac
 }
 
+function email_receiver_s3_bucket() {
+  local environment="$1"
+
+  case $environment in
+    "dev"|"staging"|"production") echo "govuk-forms-${environment}-test-emails" ;;
+    *)
+      echo "unknown environment: ${environment}"
+      exit 1
+      ;;
+  esac
+}
+
 function smoke_test_form_id() {
   local environment="$1"
 
@@ -127,6 +139,10 @@ function set_e2e_env_vars() {
   export SETTINGS__GOVUK_NOTIFY__API_KEY="$(get_param /${environment}/automated-tests/e2e/notify/api-key)"
   export SETTINGS__SUBMISSION_STATUS_API__SECRET="$(get_param /${environment}/automated-tests/e2e/runner/submission_status_api_shared_secret)"
   export SETTINGS__FORMS_ENV="$environment"
+  export SETTINGS__GOVUK_ONE_LOGIN__USER_EMAIL="$(get_param /${environment}/automated-tests/e2e/one-login/user-email)"
+  export SETTINGS__GOVUK_ONE_LOGIN__USER_PASSWORD="$(get_param /${environment}/automated-tests/e2e/one-login/user-password)"
+  export SETTINGS__GOVUK_ONE_LOGIN__USER_OTP_SECRET_KEY="$(get_param /${environment}/automated-tests/e2e/one-login/user-otp-secret-key)"
+  export SETTINGS__AWS__EMAIL_RECEIVER_S3_BUCKET_NAME="$(email_receiver_s3_bucket $environment)"
 }
 
 function set_smoke_test_env_vars() {


### PR DESCRIPTION
### What problem does this pull request solve?

Trello card: https://trello.com/c/lnW6zOUs

Update the script that retrieves the environment variables to run the end-to-end tests locally against a remote environment to load in the environment variables for the copy of answers test.

Also update the instructions for running against environment variables to use an authenticated shell for the environment under test rather than the deploy account as the user roles in the deploy account do not have the necessary permissions to assume the role needed to read from S3 buckets.

### Things to consider when reviewing

<!-- If this section isn't relevant for your PR feel free to edit or remove it -->

- Ensure that you consider the wider context.
- Does it work when run on your machine?
- Is it clear what the code is doing?
- Do the commit messages explain why the changes were made?
- Has all relevant documentation been updated?
