### PR TITLE
Add workaround for Chrome/Chromedriver issue

### DIFF
--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -28,6 +28,7 @@ if ENV["USE_CUPRITE"]
   end
 else
   require "selenium/webdriver"
+  require_relative "support/selenium_error_patch"
 
   options = Selenium::WebDriver::Chrome::Options.new
   options.add_preference(:download, prompt_for_download: false,

--- a/spec/support/selenium_error_patch.rb
+++ b/spec/support/selenium_error_patch.rb
@@ -1,0 +1,34 @@
+# Monkey patch for a specific intermittent Selenium error.
+#
+# Intermittently, Selenium/Chromedriver raises `Selenium::WebDriver::Error::UnknownError`
+# with the message "Node with given id does not belong to the document".
+
+# Capybara's automatic waiting/retrying mechanism doesn't catch it,
+# leading to failure.
+#
+# We intercept the initialization of `UnknownError`. If the message matches this specific
+# case, we raise a `StaleElementReferenceError` instead. This uses Capybara's
+# retry logic which makes doesn't fail the test
+#
+# This can be removed once the following issue is resolved:
+# https://github.com/teamcapybara/capybara/issues/2800
+#
+# taken from the following issue:
+# https://github.com/teamcapybara/capybara/issues/2800#issuecomment-3049956982
+
+module Selenium
+  module WebDriver
+    module Error
+      class UnknownError
+        alias_method :old_initialize, :initialize
+        def initialize(msg = nil)
+          if msg&.include?("Node with given id does not belong to the document")
+            raise StaleElementReferenceError, msg
+          end
+
+          old_initialize(msg)
+        end
+      end
+    end
+  end
+end


### PR DESCRIPTION
### What problem does this pull request solve?

Trello card: https://trello.com/c/bFuui8d7/3458-unpin-alpine-version-in-forms-e2e-tests-once-chromedriver-issue-is-fixed <!-- link -->

<!-- Add some description here about what the PR is about, even if you have a Trello card to link to -->

[Capybara issue 2800](https://github.com/teamcapybara/capybara/issues/2800) has still not been resolved upstream in Chrome, or in Chromedriver, Selenium, or Capybara.

We were pinning Chromium to a version not affected by this until recently, when we bumped to the latest version of Alpine (see https://github.com/govuk-forms/forms-e2e-tests/pull/307).

Now the end to end tests are again failing intermittently with `unknown error: unhandled inspector error: {"code":-32000,"message":"Node with given id does not belong to the document"}`.

This commit cherry-picks the workaround we've used in other repos to make Capybara treat this error as retryable, hopefully resolving the errors.

### Things to consider when reviewing

<!-- If this section isn't relevant for your PR feel free to edit or remove it -->

- Ensure that you consider the wider context.
- Does it work when run on your machine?
- Is it clear what the code is doing?
- Do the commit messages explain why the changes were made?
- Has all relevant documentation been updated?
