### PR TITLE
Use matcher when expecting page.current_url

### DIFF
--- a/spec/support/feature_helpers.rb
+++ b/spec/support/feature_helpers.rb
@@ -386,7 +386,7 @@ module FeatureHelpers
       click_button "Continue to GOV.UK One Login"
 
       logger.info "Then I log in using GOV.UK One Login"
-      expect(page.current_url).to match(%r{\Ahttps://signin(?:\.integration)?\.account\.gov\.uk})
+      expect(page).to have_current_path %r{\Ahttps://signin(?:\.integration)?\.account\.gov\.uk}
       click_button "Sign in"
 
       find('input[type="email"]', visible: true).set(Settings.govuk_one_login.user_email)


### PR DESCRIPTION
### What problem does this pull request solve?

<!-- Add some description here about what the PR is about, even if you have a Trello card to link to -->

The matcher `#has_current_path?` will retry if the page has not yet finished loading, whereas just checking `page.current_url` may fail immediately even though we clicked the button previously.

This was causing flaky test failures.


### Things to consider when reviewing

<!-- If this section isn't relevant for your PR feel free to edit or remove it -->

- Ensure that you consider the wider context.
- Does it work when run on your machine?
- Is it clear what the code is doing?
- Do the commit messages explain why the changes were made?
- Has all relevant documentation been updated?
