### PR TITLE
Add code to handle One Login passkey page

### DIFF
--- a/spec/support/feature_helpers.rb
+++ b/spec/support/feature_helpers.rb
@@ -397,6 +397,10 @@ module FeatureHelpers
 
       find('input[autocomplete="one-time-code"]', visible: true).set(generate_one_login_otp)
       find('button[type="submit"]').click
+
+      if page.has_text? "Set up a passkey"
+        click_button "Skip for now"
+      end
     else
       logger.info "And I choose 'No'"
       choose "No", visible: false


### PR DESCRIPTION
### What problem does this pull request solve?

<!-- Add some description here about what the PR is about, even if you have a Trello card to link to -->

One Login has enabled a new passkey flow when signing in to their integration environment. Our end to end tests include testing the "get a copy of your answers" feature, which involves signing in to One Login.

This commit adds code to skip past setting up a passkey if the page does appear. As the feature is only enabled in the One Login integration environment, we need to deal with the case when the page does not appear as well.

We should also be prepared for the design/content of the page to change in future, but this commit doesn't really do that.

### Things to consider when reviewing

<!-- If this section isn't relevant for your PR feel free to edit or remove it -->

- Ensure that you consider the wider context.
- Does it work when run on your machine?
- Is it clear what the code is doing?
- Do the commit messages explain why the changes were made?
- Has all relevant documentation been updated?
