### PR TITLE
update confirmation email test to use SES rather than notify

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,14 +30,12 @@ The tests expect an active group to exist called "End to end tests", which the t
 
 #### Starting forms-runner
 
-Forms-runner needs to be started with:
-- The Notify API key in order to send confirmation emails
-- AWS credentials for the dev account in order to send submissions
+Forms-runner needs to be started with AWS credentials for the dev account in order to send submissions.
 
 ```shell
 gds aws forms-dev-readonly --shell
 
-ASSUME_DEV_IAM_ROLE=true SETTINGS__GOVUK_NOTIFY__API_KEY=<notify-api-key> ./bin/rails server
+ASSUME_DEV_IAM_ROLE=true ./bin/rails server
 ```
 
 see the [README for forms-runner](https://github.com/govuk-forms/forms-runner?tab=readme-ov-file#getting-aws-credentials) for more details
@@ -51,9 +49,12 @@ SETTINGS__GOVUK_NOTIFY__API_KEY=<notify-api-key> ./bin/rails server
 
 #### Running the tests
 
+The tests then need to be run with AWS credentials for the dev account in order to check for the confirmation email.
 You can run the tests against localhost using the following command:
 
 ```shell
+gds aws forms-dev-readonly --shell
+
 SETTINGS__GOVUK_NOTIFY__API_KEY=<your api key> bundle exec rake
 ```
 

--- a/bin/load_env_vars.sh
+++ b/bin/load_env_vars.sh
@@ -139,6 +139,7 @@ function set_e2e_env_vars() {
   export SETTINGS__GOVUK_NOTIFY__API_KEY="$(get_param /${environment}/automated-tests/e2e/notify/api-key)"
   export SETTINGS__SUBMISSION_STATUS_API__SECRET="$(get_param /${environment}/automated-tests/e2e/runner/submission_status_api_shared_secret)"
   export SETTINGS__FORMS_ENV="$environment"
+  export SETTINGS__CONFIRMATION_EMAIL="$(confirmation_email $environment)"
   export SETTINGS__GOVUK_ONE_LOGIN__USER_EMAIL="$(get_param /${environment}/automated-tests/e2e/one-login/user-email)"
   export SETTINGS__GOVUK_ONE_LOGIN__USER_PASSWORD="$(get_param /${environment}/automated-tests/e2e/one-login/user-password)"
   export SETTINGS__GOVUK_ONE_LOGIN__USER_OTP_SECRET_KEY="$(get_param /${environment}/automated-tests/e2e/one-login/user-otp-secret-key)"

--- a/config/settings.yml
+++ b/config/settings.yml
@@ -34,3 +34,5 @@ govuk_one_login:
 
 submission_status_api:
   secret:
+
+confirmation_email:

--- a/config/settings/development.yml
+++ b/config/settings/development.yml
@@ -23,3 +23,5 @@ aws:
 
 govuk_one_login:
   user_email: copy-of-answers-emails-tests@dev.forms.service.gov.uk
+
+confirmation_email: confirmation-email-tests@dev.forms.service.gov.uk

--- a/spec/end_to_end/end_to_end_spec.rb
+++ b/spec/end_to_end/end_to_end_spec.rb
@@ -1,6 +1,7 @@
 # rubocop:todo RSpec/NoExpectationExample
 feature "Full lifecycle of a form", type: :feature do
   let(:test_email_address) { "govuk-forms-automation-tests@digital.cabinet-office.gov.uk" }
+  let(:confirmation_email) { Settings.confirmation_email }
   let(:form_name) { "capybara test form #{Time.now.strftime('%Y-%m-%d %H:%M.%S')}" }
 
   let(:file_question_text) { "Upload a file" }
@@ -80,7 +81,7 @@ feature "Full lifecycle of a form", type: :feature do
         # Testing confirmation email
         logger.info
         logger.info "Scenario: Form is completed by a member of the public, and they request a confirmation email"
-        form_is_filled_in_by_form_filler(live_form_link, confirmation_email: test_email_address)
+        form_is_filled_in_by_form_filler(live_form_link, confirmation_email: confirmation_email)
 
         unless skip_copy_of_answers?
           logger.info "Scenario: Form is completed by a member of the public, and they request a copy of their answers"

--- a/spec/support/aws_helpers.rb
+++ b/spec/support/aws_helpers.rb
@@ -29,6 +29,12 @@ module AwsHelpers
     end
   end
 
+  def wait_for_confirmation_email(submission_reference)
+    prefix = "confirmation-emails/"
+    email_match_string = "Your form reference number is #{submission_reference}"
+    wait_for_ses_email_delivered_to_s3(prefix, email_match_string, submission_reference)
+  end
+
   def wait_for_copy_of_answers_email(submission_reference)
     prefix = "copy-of-answers-emails/"
     email_match_string = "Your form reference number is #{submission_reference}"

--- a/spec/support/feature_helpers.rb
+++ b/spec/support/feature_helpers.rb
@@ -455,7 +455,12 @@ module FeatureHelpers
       logger.info "When I have filled out a form and requested a confirmation email"
       logger.info "Then I can see the confirmation in my email inbox"
 
-      wait_for_notification(confirmation_email_reference)
+      # TODO: remove this once forms-runner is sending confirmation emails with SES.
+      begin
+        wait_for_notification(confirmation_email_reference)
+      rescue NotifyException
+        wait_for_confirmation_email(submission_reference)
+      end
     end
 
     if copy_of_answers


### PR DESCRIPTION
### What problem does this pull request solve?

we are switching from using notify to send confirmation emails to using SES - this will keep it in line with the copy of answers feature. 

This pr updates the end to end tests so that they now check s3 rather than notify for the confirmation email. This includes adding a new confirmation email that has already been set up in ses.

Trello card: https://trello.com/c/GfBTJbNL/3154-use-ses-to-send-all-confirmation-emails

<!-- Add some description here about what the PR is about, even if you have a Trello card to link to -->

### Things to consider when reviewing

you can review this by running the e2e tests against the forms-runner branch: `use-ses-to-send-all-confirmation-emails`

<!-- If this section isn't relevant for your PR feel free to edit or remove it -->

- Ensure that you consider the wider context.
- Does it work when run on your machine?
- Is it clear what the code is doing?
- Do the commit messages explain why the changes were made?
- Has all relevant documentation been updated?
