### PR TITLE
remove check for notify confirmation email

### DIFF
--- a/spec/support/feature_helpers.rb
+++ b/spec/support/feature_helpers.rb
@@ -455,12 +455,7 @@ module FeatureHelpers
       logger.info "When I have filled out a form and requested a confirmation email"
       logger.info "Then I can see the confirmation in my email inbox"
 
-      # TODO: remove this once forms-runner is sending confirmation emails with SES.
-      begin
-        wait_for_notification(confirmation_email_reference)
-      rescue NotifyException
-        wait_for_confirmation_email(submission_reference)
-      end
+      wait_for_confirmation_email(submission_reference)
     end
 
     if copy_of_answers


### PR DESCRIPTION
### What problem does this pull request solve?

we have switched from using notify to using ses for confirmation emails. this commit removes a check that was left in for backwards compatability while deploying this feature. once we have switched over, we should remove this. 

I've tested this locally

Trello card: https://trello.com/c/GfBTJbNL/3154-use-ses-to-send-all-confirmation-emails

<!-- Add some description here about what the PR is about, even if you have a Trello card to link to -->

### Things to consider when reviewing

<!-- If this section isn't relevant for your PR feel free to edit or remove it -->

- Ensure that you consider the wider context.
- Does it work when run on your machine?
- Is it clear what the code is doing?
- Do the commit messages explain why the changes were made?
- Has all relevant documentation been updated?
